### PR TITLE
Cleanup deprecated types

### DIFF
--- a/packages/sprotty/src/base/actions/action-handler.ts
+++ b/packages/sprotty/src/base/actions/action-handler.ts
@@ -19,7 +19,7 @@ import { TYPES } from "../types";
 import { MultiInstanceRegistry } from "../../utils/registry";
 import { isInjectable } from "../../utils/inversify";
 import { ICommand } from "../commands/command";
-import { Action } from "./action";
+import { Action } from "sprotty-protocol";
 
 /**
  * An action handler accepts an action and reacts to it by returning either a command to be

--- a/packages/sprotty/src/base/actions/action.ts
+++ b/packages/sprotty/src/base/actions/action.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { generateRequestId as generateRequestId2 } from 'sprotty-protocol/lib/actions';
+import { generateRequestId as generateRequestId2, Action as ProtocolAction} from 'sprotty-protocol/lib/actions';
 import { JsonAny } from 'sprotty-protocol/lib/utils/json';
 import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
 
@@ -99,7 +99,7 @@ export class RejectAction implements ResponseAction {
  * to define an entry in the command palette or in the context menu.
  */
 export class LabeledAction {
-    constructor(readonly label: string, readonly actions: Action[], readonly icon?: string) { }
+    constructor(readonly label: string, readonly actions: ProtocolAction[], readonly icon?: string) { }
 }
 
 export function isLabeledAction(element: unknown): element is LabeledAction {

--- a/packages/sprotty/src/base/features/set-model.ts
+++ b/packages/sprotty/src/base/features/set-model.ts
@@ -33,7 +33,7 @@ import { InitializeCanvasBoundsCommand } from './initialize-canvas';
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class RequestModelAction implements RequestAction<SetModelAction>, ProtocolRequestModelAction {
+export class RequestModelAction implements ProtocolRequestModelAction {
     static readonly KIND = 'requestModel';
     readonly kind = RequestModelAction.KIND;
 

--- a/packages/sprotty/src/base/model/smodel.ts
+++ b/packages/sprotty/src/base/model/smodel.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { Bounds, isBounds, Point } from "sprotty-protocol/lib/utils/geometry";
+import { SModelElement as ProtocolSModelElement } from "sprotty-protocol";
 import { mapIterable, FluentIterable } from "../../utils/iterable";
 
 /**
@@ -81,8 +82,8 @@ export interface FeatureSet {
     has(feature: symbol): boolean
 }
 
-export function isParent(element: SModelElementSchema | SModelElement):
-        element is SModelElementSchema & { children: SModelElementSchema[] } {
+export function isParent(element: ProtocolSModelElement | SModelElement):
+        element is ProtocolSModelElement & { children: ProtocolSModelElement[] } {
     const children = (element as any).children;
     return children !== undefined && children.constructor === Array;
 }
@@ -213,10 +214,10 @@ export function createRandomId(length: number = 8): string {
  * Used to speed up model element lookup by id.
  */
  export interface IModelIndex {
-    add(element: SModelElementSchema): void
-    remove(element: SModelElementSchema): void
-    contains(element: SModelElementSchema): boolean
-    getById(id: string): SModelElementSchema | undefined
+    add(element:ProtocolSModelElement): void
+    remove(element: ProtocolSModelElement): void
+    contains(element: ProtocolSModelElement): boolean
+    getById(id: string): ProtocolSModelElement | undefined
 }
 
 /**

--- a/packages/sprotty/src/base/model/smodel.ts
+++ b/packages/sprotty/src/base/model/smodel.ts
@@ -214,7 +214,7 @@ export function createRandomId(length: number = 8): string {
  * Used to speed up model element lookup by id.
  */
  export interface IModelIndex {
-    add(element:ProtocolSModelElement): void
+    add(element: ProtocolSModelElement): void
     remove(element: ProtocolSModelElement): void
     contains(element: ProtocolSModelElement): boolean
     getById(id: string): ProtocolSModelElement | undefined

--- a/packages/sprotty/src/base/ui-extensions/ui-extension.ts
+++ b/packages/sprotty/src/base/ui-extensions/ui-extension.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable } from "inversify";
+import { hasOwnProperty } from "sprotty-protocol";
 import { ILogger } from "../../utils/logging";
 import { SModelRoot } from "../model/smodel";
 import { TYPES } from "../types";
@@ -26,6 +27,11 @@ export interface IUIExtension {
     id(): string;
     show(root: Readonly<SModelRoot>, ...contextElementIds: string[]): void;
     hide(): void;
+    enableOnStartup?: boolean
+}
+
+export function isUIExtension(object: unknown): object is IUIExtension {
+    return hasOwnProperty(object, 'id') && hasOwnProperty(object, 'show') && hasOwnProperty(object, 'hide');
 }
 
 /**

--- a/packages/sprotty/src/base/ui-extensions/ui-extension.ts
+++ b/packages/sprotty/src/base/ui-extensions/ui-extension.ts
@@ -31,7 +31,9 @@ export interface IUIExtension {
 }
 
 export function isUIExtension(object: unknown): object is IUIExtension {
-    return hasOwnProperty(object, 'id') && hasOwnProperty(object, 'show') && hasOwnProperty(object, 'hide');
+    return hasOwnProperty<string, Function>(object, 'id', 'function')
+    && hasOwnProperty<string, Function>(object, 'show', 'function')
+    && hasOwnProperty<string, Function>(object, 'hide', 'function');
 }
 
 /**

--- a/packages/sprotty/src/features/bounds/bounds-manipulation.ts
+++ b/packages/sprotty/src/features/bounds/bounds-manipulation.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from "inversify";
 import {
-    Action, generateRequestId, RequestAction, ResponseAction} from 'sprotty-protocol/lib/actions';
+    Action, generateRequestId, RequestAction, ResponseAction, ComputedBoundsAction as ProtocolComputedBoundsAction} from 'sprotty-protocol/lib/actions';
 import * as protocol from "sprotty-protocol/lib/actions";
 import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
@@ -198,6 +198,6 @@ export class RequestBoundsCommand extends HiddenCommand {
     }
 
     get blockUntil(): (action: Action) => boolean {
-        return action => action.kind === ComputedBoundsAction.KIND;
+        return action => action.kind === ProtocolComputedBoundsAction.KIND;
     }
 }

--- a/packages/sprotty/src/features/button/model.ts
+++ b/packages/sprotty/src/features/button/model.ts
@@ -14,8 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { boundsFeature, layoutableChildFeature, SShapeElement, SShapeElementSchema } from '../bounds/model';
+import { boundsFeature, layoutableChildFeature, SShapeElement } from '../bounds/model';
 import { fadeFeature } from '../fade/model';
+import { SShapeElement as SShapeElementSchema } from 'sprotty-protocol';
 
 export interface SButtonSchema extends SShapeElementSchema {
     pressed: boolean

--- a/packages/sprotty/src/features/edit/create.ts
+++ b/packages/sprotty/src/features/edit/create.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, CreateElementAction as ProtocolCreateElementAction } from 'sprotty-protocol/lib/actions';
 import { SModelElement as SModelElementSchema } from 'sprotty-protocol/lib/model';
 import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
 import { SParentElement, SChildElement } from '../../base/model/smodel';
@@ -45,12 +45,12 @@ export namespace CreateElementAction {
 
 @injectable()
 export class CreateElementCommand extends Command {
-    static readonly KIND = CreateElementAction.KIND;
+    static readonly KIND = ProtocolCreateElementAction.KIND;
 
     container: SParentElement;
     newElement: SChildElement;
 
-    constructor(@inject(TYPES.Action) protected readonly action: CreateElementAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolCreateElementAction) {
         super();
     }
 

--- a/packages/sprotty/src/features/edit/delete.ts
+++ b/packages/sprotty/src/features/edit/delete.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, DeleteElementAction as ProtocolDeleteElementAction} from 'sprotty-protocol/lib/actions';
 import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
 import { SModelElement, SParentElement, SChildElement } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
@@ -57,11 +57,11 @@ export class ResolvedDelete {
 
 @injectable()
 export class DeleteElementCommand extends Command {
-    static readonly KIND = DeleteElementAction.KIND;
+    static readonly KIND = ProtocolDeleteElementAction.KIND;
 
     resolvedDeletes: ResolvedDelete[] = [];
 
-    constructor(@inject(TYPES.Action) protected readonly action: DeleteElementAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolDeleteElementAction) {
         super();
     }
 

--- a/packages/sprotty/src/features/edit/edit-label.ts
+++ b/packages/sprotty/src/features/edit/edit-label.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject } from 'inversify';
-import { Action, isAction } from 'sprotty-protocol/lib/actions';
+import { Action, isAction, ApplyLabelEditAction as ProtocolApplyLabelEditAction } from 'sprotty-protocol/lib/actions';
 import { CommandExecutionContext, CommandReturn, Command } from '../../base/commands/command';
 import { SModelElement } from '../../base/model/smodel';
 import { TYPES } from '../../base/types';
@@ -66,8 +66,8 @@ export namespace ApplyLabelEditAction {
     }
 }
 
-export function isApplyLabelEditAction(element?: any): element is ApplyLabelEditAction {
-    return isAction(element) && element.kind === ApplyLabelEditAction.KIND && 'labelId' in element && 'text' in element;
+export function isApplyLabelEditAction(element?: any): element is ProtocolApplyLabelEditAction {
+    return isAction(element) && element.kind === ProtocolApplyLabelEditAction.KIND && 'labelId' in element && 'text' in element;
 }
 
 
@@ -78,11 +78,11 @@ export class ResolvedLabelEdit {
 }
 
 export class ApplyLabelEditCommand extends Command {
-    static readonly KIND = ApplyLabelEditAction.KIND;
+    static readonly KIND = ProtocolApplyLabelEditAction.KIND;
 
     protected resolvedLabelEdit: ResolvedLabelEdit;
 
-    constructor(@inject(TYPES.Action) protected readonly action: ApplyLabelEditAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolApplyLabelEditAction) {
         super();
     }
 

--- a/packages/sprotty/src/features/edit/reconnect.ts
+++ b/packages/sprotty/src/features/edit/reconnect.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, ReconnectAction as ProtocolReconnectAction} from 'sprotty-protocol/lib/actions';
 import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
 import { TYPES } from '../../base/types';
 import { SRoutableElement } from '../routing/model';
@@ -45,13 +45,13 @@ export namespace ReconnectAction {
 
 @injectable()
 export class ReconnectCommand extends Command {
-    static readonly KIND = ReconnectAction.KIND;
+    static readonly KIND = ProtocolReconnectAction.KIND;
 
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
 
     memento: EdgeMemento | undefined;
 
-    constructor(@inject(TYPES.Action) protected readonly action: ReconnectAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolReconnectAction) {
         super();
     }
 

--- a/packages/sprotty/src/features/move/move.ts
+++ b/packages/sprotty/src/features/move/move.ts
@@ -17,7 +17,7 @@
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
 import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { Action, DeleteElementAction, ReconnectAction, SelectAction, SelectAllAction } from 'sprotty-protocol/lib/actions';
+import { Action, DeleteElementAction, ReconnectAction, SelectAction, SelectAllAction, MoveAction as ProtocolMoveAction } from 'sprotty-protocol/lib/actions';
 import { Animation, CompoundAnimation } from '../../base/animations/animation';
 import { CommandExecutionContext, ICommand, MergeableCommand, CommandReturn } from '../../base/commands/command';
 import { SChildElement, SModelElement, SModelRoot } from '../../base/model/smodel';
@@ -83,14 +83,14 @@ export interface ResolvedHandleMove {
 
 @injectable()
 export class MoveCommand extends MergeableCommand {
-    static readonly KIND = MoveAction.KIND;
+    static readonly KIND = ProtocolMoveAction.KIND;
 
     @inject(EdgeRouterRegistry) @optional() edgeRouterRegistry?: EdgeRouterRegistry;
 
     protected resolvedMoves: Map<string, ResolvedElementMove> = new Map;
     protected edgeMementi: EdgeMemento[] = [];
 
-    constructor(@inject(TYPES.Action) protected readonly action: MoveAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolMoveAction) {
         super();
     }
 
@@ -475,7 +475,7 @@ export class MoveMouseListener extends MouseListener {
         return false;
     }
 
-    protected getElementMoves(target: SModelElement, event: MouseEvent, isFinished: boolean): MoveAction | undefined {
+    protected getElementMoves(target: SModelElement, event: MouseEvent, isFinished: boolean): ProtocolMoveAction | undefined {
         if (!this.startDragPosition)
             return undefined;
         const elementMoves: ElementMove[] = [];
@@ -495,7 +495,7 @@ export class MoveMouseListener extends MouseListener {
             }
         });
         if (elementMoves.length > 0)
-            return MoveAction.create(elementMoves, { animate: false, finished: isFinished });
+            return ProtocolMoveAction.create(elementMoves, { animate: false, finished: isFinished });
         else
             return undefined;
     }

--- a/packages/sprotty/src/features/select/select.ts
+++ b/packages/sprotty/src/features/select/select.ts
@@ -255,7 +255,7 @@ export class SelectMouseListener extends MouseListener {
 
     protected handleSelectTarget(selectableTarget: SModelElement & Selectable, deselectedElements: SModelElement[], event: MouseEvent): (Action | Promise<Action>)[] {
         const result: Action[] = [];
-        result.push(new SelectAction([selectableTarget.id], deselectedElements.map(e => e.id)));
+        result.push(ProtocolSelectAction.create({ selectedElementsIDs: [selectableTarget.id], deselectedElementsIDs: deselectedElements.map(e => e.id) }));
         result.push(BringToFrontAction.create([selectableTarget.id]));
         const routableDeselect = deselectedElements.filter(e => e instanceof SRoutableElement).map(e => e.id);
         if (selectableTarget instanceof SRoutableElement) {
@@ -268,7 +268,7 @@ export class SelectMouseListener extends MouseListener {
 
     protected handleDeselectTarget(selectableTarget: SModelElement & Selectable, event: MouseEvent): (Action | Promise<Action>)[] {
         const result: Action[] = [];
-        result.push(new SelectAction([], [selectableTarget.id]));
+        result.push(ProtocolSelectAction.create({ selectedElementsIDs: [], deselectedElementsIDs: [selectableTarget.id] }));
         if (selectableTarget instanceof SRoutableElement) {
             result.push(SwitchEditModeAction.create({ elementsToDeactivate: [selectableTarget.id] }));
         }
@@ -277,7 +277,7 @@ export class SelectMouseListener extends MouseListener {
 
     protected handleDeselectAll(deselectedElements: SModelElement[], event: MouseEvent): (Action | Promise<Action>)[] {
         const result: Action[] = [];
-        result.push(new SelectAction([], deselectedElements.map(e => e.id)));
+        result.push(ProtocolSelectAction.create({ selectedElementsIDs: [], deselectedElementsIDs: deselectedElements.map(e => e.id) }));
         const routableDeselect = deselectedElements.filter(e => e instanceof SRoutableElement).map(e => e.id);
         if (routableDeselect.length > 0) {
             result.push(SwitchEditModeAction.create({ elementsToDeactivate: routableDeselect }));
@@ -339,7 +339,7 @@ export class GetSelectionCommand extends ModelRequestCommand {
 export class SelectKeyboardListener extends KeyListener {
     override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyA', 'ctrlCmd')) {
-            return [new SelectAllAction()];
+            return [ ProtocolSelectAllActon.create()];
         }
         return [];
     }

--- a/packages/sprotty/src/features/select/select.ts
+++ b/packages/sprotty/src/features/select/select.ts
@@ -296,7 +296,7 @@ export class SelectMouseListener extends MouseListener {
                 const selectableTarget = findParentByFeature(target, isSelectable);
                 if (selectableTarget !== undefined) {
                     if (this.wasSelected) {
-                        return [new SelectAction([selectableTarget.id], [])];
+                        return [ProtocolSelectAction.create({selectedElementsIDs:[selectableTarget.id],deselectedElementsIDs:[]})];
                     }
                 } else if (target instanceof SModelRoot && !findViewportScrollbar(event)) {
                     // Mouse up on root but not over ViewPort's scroll bars > deselect all

--- a/packages/sprotty/src/features/undo-redo/undo-redo.ts
+++ b/packages/sprotty/src/features/undo-redo/undo-redo.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, UndoAction as ProtocolUndoAction, RedoAction as ProtocolRedoAction } from 'sprotty-protocol/lib/actions';
 import { matchesKeystroke } from '../../utils/keyboard';
 import { KeyListener } from '../../base/views/key-tool';
 import { SModelElement } from '../../base/model/smodel';
@@ -55,9 +55,9 @@ export namespace RedoAction {
 export class UndoRedoKeyListener extends KeyListener {
     override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyZ', 'ctrlCmd'))
-            return [UndoAction.create()];
+            return [ProtocolUndoAction.create()];
         if (matchesKeystroke(event, 'KeyZ', 'ctrlCmd', 'shift') || (!isMac() && matchesKeystroke(event, 'KeyY', 'ctrlCmd')))
-            return [RedoAction.create()];
+            return [ProtocolRedoAction.create()];
         return [];
     }
 }

--- a/packages/sprotty/src/features/viewport/center-fit.ts
+++ b/packages/sprotty/src/features/viewport/center-fit.ts
@@ -229,9 +229,9 @@ export class FitToScreenCommand extends BoundsAwareViewportCommand {
 export class CenterKeyboardListener extends KeyListener {
     override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyC', 'ctrlCmd', 'shift'))
-            return [new CenterAction([])];
+            return [ProtocolCenterAction.create([])];
         if (matchesKeystroke(event, 'KeyF', 'ctrlCmd', 'shift'))
-            return [new FitToScreenAction([])];
+            return [ProtocolFitToScreenAction.create([])];
         return [];
     }
 }

--- a/packages/sprotty/src/features/viewport/model.ts
+++ b/packages/sprotty/src/features/viewport/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Scrollable, Zoomable } from 'sprotty-protocol/lib/model';
+import { Scrollable, Zoomable, Viewport as ProtocolViewport } from 'sprotty-protocol/lib/model';
 import { SModelElement, SModelRoot } from '../../base/model/smodel';
 
 export const viewportFeature = Symbol('viewportFeature');
@@ -25,7 +25,7 @@ export const viewportFeature = Symbol('viewportFeature');
 export interface Viewport extends Scrollable, Zoomable {
 }
 
-export function isViewport(element: SModelElement): element is SModelRoot & Viewport {
+export function isViewport(element: SModelElement): element is SModelRoot & ProtocolViewport {
     return element instanceof SModelRoot
         && element.hasFeature(viewportFeature)
         && 'zoom' in element

--- a/packages/sprotty/src/features/zorder/zorder.ts
+++ b/packages/sprotty/src/features/zorder/zorder.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, BringToFrontAction as ProtocolBringToFrontAction} from 'sprotty-protocol/lib/actions';
 import { TYPES } from '../../base/types';
 import { SModelRoot, SChildElement, SModelElement, SParentElement } from '../../base/model/smodel';
 import { Command, CommandExecutionContext } from '../../base/commands/command';
@@ -48,11 +48,11 @@ export type ZOrderElement = {
 
 @injectable()
 export class BringToFrontCommand extends Command {
-    static readonly KIND = BringToFrontAction.KIND;
+    static readonly KIND = ProtocolBringToFrontAction.KIND;
 
     protected selected: ZOrderElement[] = [];
 
-    constructor(@inject(TYPES.Action) public action: BringToFrontAction) {
+    constructor(@inject(TYPES.Action) public action: ProtocolBringToFrontAction) {
         super();
     }
 

--- a/packages/sprotty/src/model-source/diagram-server.ts
+++ b/packages/sprotty/src/model-source/diagram-server.ts
@@ -16,7 +16,7 @@
 
 import { saveAs } from 'file-saver';
 import { inject, injectable } from "inversify";
-import { OpenAction } from 'sprotty-protocol';
+import { OpenAction, ActionMessage as ProtocolActionMessage, isActionMessage as isProtocolActionMessage } from 'sprotty-protocol';
 import {
     Action, CollapseExpandAction, CollapseExpandAllAction, ComputedBoundsAction, RequestModelAction,
     RequestPopupModelAction, SetModelAction, UpdateModelAction
@@ -107,7 +107,7 @@ export abstract class DiagramServerProxy extends ModelSource {
     }
 
     protected forwardToServer(action: Action): void {
-        const message: ActionMessage = {
+        const message: ProtocolActionMessage = {
             clientId: this.clientId,
             action: action
         };
@@ -115,11 +115,11 @@ export abstract class DiagramServerProxy extends ModelSource {
         this.sendMessage(message);
     }
 
-    protected abstract sendMessage(message: ActionMessage): void;
+    protected abstract sendMessage(message: ProtocolActionMessage): void;
 
     protected messageReceived(data: any): void {
         const object = typeof(data) === 'string' ? JSON.parse(data) : data;
-        if (isActionMessage(object) && object.action) {
+        if (isProtocolActionMessage(object) && object.action) {
             if (!object.clientId || object.clientId === this.clientId) {
                 (object.action as any)[receivedFromServerProperty] = true;
                 this.logger.log(this, 'receiving', object);

--- a/packages/sprotty/src/model-source/local-model-source.ts
+++ b/packages/sprotty/src/model-source/local-model-source.ts
@@ -20,7 +20,8 @@ import {
     Action, ComputedBoundsAction, RequestBoundsAction, RequestModelAction, RequestPopupModelAction,
     SetModelAction, SetPopupModelAction, UpdateModelAction
 } from 'sprotty-protocol/lib/actions';
-import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema, Viewport } from 'sprotty-protocol/lib/model';
+import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema, Viewport} from 'sprotty-protocol/lib/model';
+import { IModelLayoutEngine as ProtocolIModelLayoutEngine } from 'sprotty-protocol';
 import { Bounds } from 'sprotty-protocol/lib/utils/geometry';
 import { SModelIndex, findElement } from 'sprotty-protocol/lib/utils/model-utils';
 import { ILogger } from "../utils/logging";
@@ -45,7 +46,7 @@ export class LocalModelSource extends ModelSource {
     @inject(TYPES.ILogger) protected readonly logger: ILogger;
     @inject(ComputedBoundsApplicator) protected readonly computedBoundsApplicator: ComputedBoundsApplicator;
     @inject(TYPES.IPopupModelProvider)@optional() protected popupModelProvider?: IPopupModelProvider;
-    @inject(TYPES.IModelLayoutEngine)@optional() protected layoutEngine?: IModelLayoutEngine;
+    @inject(TYPES.IModelLayoutEngine)@optional() protected layoutEngine?: ProtocolIModelLayoutEngine;
 
     protected currentRoot: SModelRootSchema = EMPTY_ROOT;
 

--- a/packages/sprotty/src/model-source/logging.ts
+++ b/packages/sprotty/src/model-source/logging.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, LoggingAction as ProtocolLoggingAction } from 'sprotty-protocol/lib/actions';
 import { ILogger, LogLevel } from '../utils/logging';
 import { TYPES } from '../base/types';
 import { ModelSource } from './model-source';
@@ -78,7 +78,7 @@ export class ForwardingLogger implements ILogger {
 
     protected forward(thisArg: any, message: string, logLevel: LogLevel, params: any[]) {
         const date = new Date();
-        const action = LoggingAction.create({
+        const action = ProtocolLoggingAction.create({
             message,
             severity: LogLevel[logLevel],
             time: date.toLocaleTimeString(),

--- a/packages/sprotty/src/utils/geometry.ts
+++ b/packages/sprotty/src/utils/geometry.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Bounds as ProtocolBounds, Point as ProtocolPoint, toDegrees as protocolToDegrees } from "sprotty-protocol";
 /**
  * A Point is composed of the (x,y) coordinates of an object.
  *
@@ -394,30 +395,30 @@ export function linear(p0: Point, p1: Point, lambda: number): Point {
  */
 export class Diamond {
 
-    constructor(protected bounds: Bounds) { }
+    constructor(protected bounds: ProtocolBounds) { }
 
-    get topPoint(): Point {
+    get topPoint(): ProtocolPoint {
         return {
             x: this.bounds.x + this.bounds.width / 2,
             y: this.bounds.y
         };
     }
 
-    get rightPoint(): Point {
+    get rightPoint(): ProtocolPoint {
         return {
             x: this.bounds.x + this.bounds.width,
             y: this.bounds.y + this.bounds.height / 2
         };
     }
 
-    get bottomPoint(): Point {
+    get bottomPoint(): ProtocolPoint {
         return {
             x: this.bounds.x + this.bounds.width / 2,
             y: this.bounds.y + this.bounds.height
         };
     }
 
-    get leftPoint(): Point {
+    get leftPoint(): ProtocolPoint {
         return {
             x: this.bounds.x,
             y: this.bounds.y + this.bounds.height / 2
@@ -445,8 +446,8 @@ export class Diamond {
      * @param {Point} refPoint a reference point
      * @returns {Line} a line representing the closest side
      */
-    closestSideLine(refPoint: Point): Line {
-        const c = center(this.bounds);
+    closestSideLine(refPoint: ProtocolPoint): Line {
+        const c = ProtocolBounds.center(this.bounds);
         if (refPoint.x > c.x) {
             if (refPoint.y > c.y) {
                 return this.bottomRightSideLine;
@@ -481,7 +482,7 @@ export type CardinalDirection =
  */
 export class PointToPointLine implements Line {
 
-    constructor(public p1: Point, public p2: Point) { }
+    constructor(public p1: ProtocolPoint, public p2: ProtocolPoint) { }
 
     get a(): number {
         return this.p1.y - this.p2.y;
@@ -525,7 +526,7 @@ export class PointToPointLine implements Line {
      * The direction of this line, such as 'north', 'south', or 'south-west'.
      */
     get direction(): CardinalDirection {
-        const hDegrees = toDegrees(this.angle);
+        const hDegrees = protocolToDegrees(this.angle);
         const degrees = hDegrees < 0 ? 360 + hDegrees : hDegrees;
         // degrees are relative to the x-axis
         if (degrees === 90) {
@@ -552,7 +553,7 @@ export class PointToPointLine implements Line {
      * @param otherLine the other line
      * @returns the intersection point between `this` line and the `otherLine` if exists, or `undefined`.
      */
-    intersection(otherLine: PointToPointLine): Point | undefined {
+    intersection(otherLine: PointToPointLine): ProtocolPoint | undefined {
         if (this.hasIndistinctPoints(otherLine)) {
             return undefined;
         }
@@ -593,10 +594,10 @@ export class PointToPointLine implements Line {
      * or end points with the `otherLine`
      */
     hasIndistinctPoints(otherLine: PointToPointLine): boolean {
-        return pointEquals(this.p1, otherLine.p1) ||
-            pointEquals(this.p1, otherLine.p2) ||
-            pointEquals(this.p2, otherLine.p1) ||
-            pointEquals(this.p2, otherLine.p2);
+        return ProtocolPoint.equals(this.p1, otherLine.p1) ||
+            ProtocolPoint.equals(this.p1, otherLine.p2) ||
+            ProtocolPoint.equals(this.p2, otherLine.p1) ||
+            ProtocolPoint.equals(this.p2, otherLine.p2);
     }
 }
 
@@ -606,7 +607,7 @@ export class PointToPointLine implements Line {
  * @param {Line} l2 - Another line
  * @returns {Point} The intersection point of `l1` and `l2`
  */
-export function intersection(l1: Line, l2: Line): Point {
+export function intersection(l1: Line, l2: Line): ProtocolPoint {
     return {
         x: (l1.c * l2.b - l2.c * l1.b) / (l1.a * l2.b - l2.a * l1.b),
         y: (l1.a * l2.c - l2.a * l1.c) / (l1.a * l2.b - l2.a * l1.b)


### PR DESCRIPTION
Ensure that deprecated types are isolated and don't leak into non-deprecated  definitions. => Consistently use definitions from sprotty protocol in non-deprecated  classes,functions or type definitions.