### PR TITLE
Reconnecting of edges breaks dragging #335

### DIFF
--- a/packages/sprotty/src/features/move/move.ts
+++ b/packages/sprotty/src/features/move/move.ts
@@ -409,9 +409,9 @@ export class MoveMouseListener extends MouseListener {
             }
             this.hasDragged = false;
             if (isCreatingOnDrag(target)) {
-                this.startCreatingOnDrag(target, event);
+                return this.startCreatingOnDrag(target, event);
             } else if (isRoutingHandle) {
-                this.activateRoutingHandle(target, event);
+                return this.activateRoutingHandle(target, event);
             }
         }
         return [];


### PR DESCRIPTION
Fixes ` Error: Duplicate ID in model: edge0_dangling-source`, see #335

How to test: Open the Class diagram example. You should be able to reconnect edges more than once. 