### PR TITLE
Don't lose selection when clicking over root

### DIFF
--- a/packages/sprotty/src/features/viewport/scroll.ts
+++ b/packages/sprotty/src/features/viewport/scroll.ts
@@ -180,14 +180,7 @@ export class ScrollMouseListener extends MouseListener {
     }
 
     protected getScrollbar(event: MouseEvent): HTMLElement | undefined {
-        let element = event.target as HTMLElement | null;
-        while (element) {
-            if (element.classList && element.classList.contains('sprotty-projection-bar')) {
-                return element;
-            }
-            element = element.parentElement;
-        }
-        return undefined;
+        return findViewportScrollbar(event);
     }
 
     protected getScrollbarOrientation(scrollbar: HTMLElement): 'horizontal' | 'vertical' {
@@ -208,4 +201,15 @@ export class ScrollMouseListener extends MouseListener {
         return undefined;
     }
 
+}
+
+export function findViewportScrollbar(event: MouseEvent): HTMLElement | undefined {
+    let element = event.target as HTMLElement | null;
+    while (element) {
+        if (element.classList && element.classList.contains('sprotty-projection-bar')) {
+            return element;
+        }
+        element = element.parentElement;
+    }
+    return undefined;
 }


### PR DESCRIPTION
- Prevents losing selection when panning with the mouse
- Single click on model root still deselects all elements.
- Also fixes the selection los when using scroll bars #302  

How to verify:
- select one or more elements in an example project
- pan with the mouse - selection should remain the same
- click the root area - selection should be reseted