### PR TITLE
specify host as 127.0.0.1

### DIFF
--- a/packages/sprotty-elk/src/node/socket-server.ts
+++ b/packages/sprotty-elk/src/node/socket-server.ts
@@ -97,7 +97,7 @@ export class SocketElkServer implements ELK {
                 this.socket = undefined;
                 reject(err);
             });
-            socket.connect(this.port);
+            socket.connect(this.port, "127.0.0.1");
             this.socket = socket;
             socket.on('ready', () => resolve(socket));
         });


### PR DESCRIPTION
When running the random graph generator example, I see an error like:
<img width="328" alt="Screen Shot 2023-02-18 at 8 36 23 PM" src="https://user-images.githubusercontent.com/9464913/219907408-4a95fcbc-7d69-453b-a6e1-69100cb195d9.png">

I noticed the host name looked odd. I found [this SO post](https://stackoverflow.com/questions/10643965/econnrefused-error-with-node-js-that-does-not-occur-in-other-clients) and [this SO post](https://stackoverflow.com/questions/73843720/connect-econnrefused-127017) that explain that node has issues with `localhost` and to use `127.0.0.1` instead. So, I made this change locally to the socket connect call and it fixed the issue:
<img width="1159" alt="Screen Shot 2023-02-18 at 8 37 40 PM" src="https://user-images.githubusercontent.com/9464913/219907451-9c02905f-4188-4da1-ac47-d5e33146931d.png">
