### PR TITLE
Allow context menu on not selectable elements #345

### DIFF
--- a/examples/classdiagram/class-diagram.html
+++ b/examples/classdiagram/class-diagram.html
@@ -26,7 +26,7 @@
                 <div id="sprotty" class="sprotty"/>
             </div>
             <div class="copyright">
-                &copy; 2021 <a href="https://www.typefox.io/">TypeFox GmbH</a>.
+                &copy; 2023 <a href="https://www.typefox.io/">TypeFox GmbH</a>.
             </div>
         </div>
     </div>

--- a/examples/classdiagram/css/diagram.css
+++ b/examples/classdiagram/css/diagram.css
@@ -88,37 +88,37 @@
     stroke-width: 3px;
 }
 
-.sprotty-edge > .sprotty-routing-handle {
+.sprotty-edge>.sprotty-routing-handle {
     fill: #884;
     stroke: none;
     z-index: 1000;
 }
 
-.sprotty-edge > .sprotty-routing-handle[data-kind='line'] {
+.sprotty-edge>.sprotty-routing-handle[data-kind='line'] {
     opacity: 0.35;
 }
 
-.sprotty-edge > .sprotty-routing-handle[data-kind='bezier-add'] {
+.sprotty-edge>.sprotty-routing-handle[data-kind='bezier-add'] {
     fill: #2B2;
 }
 
-.sprotty-edge > .sprotty-routing-handle[data-kind='bezier-remove'] {
+.sprotty-edge>.sprotty-routing-handle[data-kind='bezier-remove'] {
     fill: #B00;
 }
 
-.sprotty-edge > .sprotty-routing-handle[data-kind='bezier-control-before'] {
+.sprotty-edge>.sprotty-routing-handle[data-kind='bezier-control-before'] {
     fill: #44E;
 }
 
-.sprotty-edge > .sprotty-routing-handle[data-kind='bezier-control-after'] {
+.sprotty-edge>.sprotty-routing-handle[data-kind='bezier-control-after'] {
     fill: #44E;
 }
 
-.sprotty-edge > .sprotty-routing-handle.selected {
+.sprotty-edge>.sprotty-routing-handle.selected {
     fill: #66a;
 }
 
-.sprotty-edge > .sprotty-routing-handle.mouseover {
+.sprotty-edge>.sprotty-routing-handle.mouseover {
     stroke: #112;
     stroke-width: 1;
 }
@@ -136,6 +136,43 @@
     margin-bottom: 10px;
 }
 
-.sprotty-popup-body > p {
+.sprotty-popup-body>p {
     margin-bottom: 2px;
+}
+
+.class-context-menu {
+    background-color: #dee2e6;
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    border: 1px solid #adb5bd;
+    border-radius: 3px;
+    padding: 1px;
+}
+
+.class-context-menu-item {
+    background-color: #dee2e6;
+    padding: 2px;
+    padding-left: 15px;
+    padding-right: 15px;
+    min-width: 100px;
+    font-family: sans-serif;
+    cursor: default;
+}
+
+.class-context-menu-item.disabled-action {
+    color: darkgray;
+}
+
+.class-context-menu-item:empty {
+    padding: 0px;
+    border-bottom: 1.5px solid #adb5bd;
+    margin-left: 15px;
+    margin-right: 15px;
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+.class-context-menu-item:hover:not(.disabled-action) {
+    color: green;
 }

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -24,12 +24,13 @@ import {
     RectangularNode, BezierCurveEdgeView, SBezierCreateHandleView, SBezierControlHandleView
 } from 'sprotty';
 import edgeIntersectionModule from "sprotty/lib/features/edge-intersection/di.config";
-import { IconView, NodeView} from "./views";
-import { PopupModelProvider } from "./popup";
-import { ClassDiagramModelSource } from './model-source';
-import { ClassDiagramLabelValidator, ClassDiagramLabelValidationDecorator } from './label-validation';
-import { Icon, ClassNode, ClassLabel, PropertyLabel } from "./model";
 import { BezierMouseListener } from 'sprotty/lib/features/routing/bezier-edge-router';
+import { ClassDiagramLabelValidationDecorator, ClassDiagramLabelValidator } from './label-validation';
+import { ClassContextMenuItemProvider, ClassContextMenuService } from './menu';
+import { ClassLabel, ClassNode, Icon, PropertyLabel } from "./model";
+import { ClassDiagramModelSource } from './model-source';
+import { PopupModelProvider } from "./popup";
+import { IconView, NodeView } from "./views";
 
 export default (containerId: string) => {
     require("sprotty/css/sprotty.css");
@@ -49,6 +50,8 @@ export default (containerId: string) => {
         bind(TYPES.IEditLabelValidationDecorator).to(ClassDiagramLabelValidationDecorator);
         bind(BezierMouseListener).toSelf().inSingletonScope();
         bind(TYPES.MouseListener).toService(BezierMouseListener);
+        bind(TYPES.IContextMenuService).to(ClassContextMenuService);
+        bind(TYPES.IContextMenuItemProvider).to(ClassContextMenuItemProvider);
 
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);

--- a/examples/classdiagram/src/menu.ts
+++ b/examples/classdiagram/src/menu.ts
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2023 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from "inversify";
+import { Anchor, DeleteElementAction, EMPTY_ROOT, GetSelectionAction, IActionDispatcher, IContextMenuItemProvider, IContextMenuService, LabeledAction, MenuItem, RequestExportSvgAction, SelectionResult, SModelRoot, TYPES, ViewerOptions } from "sprotty";
+import { CenterAction, FitToScreenAction, Point, SetPopupModelAction } from "sprotty-protocol";
+
+@injectable()
+export class ClassContextMenuService implements IContextMenuService {
+
+    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
+    @inject(TYPES.ViewerOptions) protected viewerOptions: ViewerOptions;
+
+    show(items: MenuItem[], anchor: Anchor, onHide?: (() => void) | undefined): void {
+        this.actionDispatcher.dispatch(SetPopupModelAction.create(EMPTY_ROOT))
+        const container = document.getElementById(this.viewerOptions.baseDiv);
+        let menuNode: HTMLDivElement;
+        const hideMenu = () => {
+            container?.removeChild(menuNode);
+            if (onHide) {
+                onHide()
+            }
+        }
+        menuNode = this.createMenu(items, hideMenu);
+        menuNode.style.top = (anchor.y - 5) + 'px'
+        menuNode.style.left = (anchor.x - 5) + 'px'
+
+
+        container?.appendChild(menuNode);
+        menuNode.onmouseleave = (e: MouseEvent) => hideMenu();
+    }
+
+    protected createMenu(items: MenuItem[], closeCallback: () => void): HTMLDivElement {
+        const menuNode = document.createElement('div');
+        menuNode.id = 'class-context-menu';
+        menuNode.classList.add('class-context-menu');
+        items.forEach((item, index) => {
+            const menuItem = document.createElement('div');
+            menuItem.id = 'class-context-menu-item-' + index;
+            menuItem.classList.add('class-context-menu-item');
+            const itemEnabled = item.isEnabled ? item.isEnabled() : true;
+            if (!itemEnabled)
+                menuItem.classList.add('disabled-action');
+            menuItem.textContent = item.label;
+            menuItem.onclick = (e: MouseEvent) => {
+                closeCallback();
+                if (itemEnabled && item.actions.length > 0) {
+                    this.actionDispatcher.dispatchAll(item.actions);
+                }
+            }
+            menuNode.appendChild(menuItem);
+        });
+        return menuNode;
+    }
+}
+
+@injectable()
+export class ClassContextMenuItemProvider implements IContextMenuItemProvider {
+
+    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
+
+    async getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point | undefined): Promise<LabeledAction[]> {
+        const selectionResult = await this.actionDispatcher.request<SelectionResult>(GetSelectionAction.create())
+        return [
+            new LabeledAction('Fit Diagram to Screen', [FitToScreenAction.create(root.children.map(child => child.id))]),
+            new LabeledAction('Center Selection', [CenterAction.create(selectionResult.selectedElementsIDs)]),
+            new LabeledAction('', []),
+            new LabeledAction('Export SVG', [RequestExportSvgAction.create()]),
+            new LabeledAction('', []),
+            {
+                ...new LabeledAction('Delete Selected', [DeleteElementAction.create(selectionResult.selectedElementsIDs)]),
+                isEnabled: () => {
+                    return selectionResult.selectedElementsIDs.length > 0
+                }
+            } as MenuItem
+        ];
+    }
+
+}

--- a/packages/sprotty/src/features/context-menu/mouse-listener.ts
+++ b/packages/sprotty/src/features/context-menu/mouse-listener.ts
@@ -46,23 +46,25 @@ export class ContextMenuMouseListener extends MouseListener {
             // IContextMenuService is not bound => do nothing
             return;
         }
-        const mousePosition = { x: event.x, y: event.y };
-        const root = target.root;
-        const id = target.id;
+
         let isTargetSelected = false;
         const selectableTarget = findParentByFeature(target, isSelectable);
         if (selectableTarget) {
             isTargetSelected = selectableTarget.selected;
             selectableTarget.selected = true;
         }
-        const restoreSelection = () => { if (selectableTarget) selectableTarget.selected = isTargetSelected; };
 
+        const root = target.root;
+        const mousePosition = { x: event.x, y: event.y };
         if (target.id === root.id || isSelected(selectableTarget)) {
             const menuItems = await this.menuProvider.getItems(root, mousePosition);
+            const restoreSelection = () => { if (selectableTarget) selectableTarget.selected = isTargetSelected; };
             menuService.show(menuItems, mousePosition, restoreSelection);
         } else {
-            const options = { selectedElementsIDs: [id], deselectedElementsIDs: Array.from(root.index.all().filter(isSelected), (val) => { return val.id; }) };
-            await this.actionDispatcher.dispatch(SelectAction.create(options));
+            if (isSelectable(target)) {
+                const options = { selectedElementsIDs: [target.id], deselectedElementsIDs: Array.from(root.index.all().filter(isSelected), (val) => { return val.id; }) };
+                await this.actionDispatcher.dispatch(SelectAction.create(options));
+            }
             const items = await this.menuProvider.getItems(root, mousePosition);
             menuService.show(items, mousePosition);
         }


### PR DESCRIPTION
As in a lot of cases the target element must not be selectable I removed the if condition from `menu-listener.ts`.
- In case of a non selectable element the next selectable parent will be checked.
- In case of root (normally not selectable) the menu will be shown too

I also added a context menu to our class diagram example so we can discuss the current selection behavior.
Please note that a lot of actions act on elements that they retrieve from the available selection tracking services (e.g. GetSelectionAction or LocalModelSource.getSelection). 