### PR TITLE
added zoomScale property to centerAction to set zoom level when executing the action

### DIFF
--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -463,16 +463,18 @@ export interface CenterAction extends Action {
     elementIds: string[]
     animate: boolean
     retainZoom: boolean
+    zoomScale?: number
 }
 export namespace CenterAction {
     export const KIND = 'center';
 
-    export function create(elementIds: string[], options: { animate?: boolean, retainZoom?: boolean } = {}): CenterAction {
+    export function create(elementIds: string[], options: { animate?: boolean, retainZoom?: boolean, zoomScale?: number } = {}): CenterAction {
         return {
             kind: KIND,
             elementIds,
             animate: options.animate ?? true,
-            retainZoom: options.retainZoom ?? false
+            retainZoom: options.retainZoom ?? false,
+            zoomScale: options.zoomScale
         };
     }
 }

--- a/packages/sprotty/src/features/viewport/center-fit.ts
+++ b/packages/sprotty/src/features/viewport/center-fit.ts
@@ -44,7 +44,8 @@ export class CenterAction implements Action, ProtocolCenterAction {
 
     constructor(public readonly elementIds: string[],
                 public readonly animate: boolean = true,
-                public readonly retainZoom: boolean = false) {
+                public readonly retainZoom: boolean = false,
+                public readonly zoomScale?: number) {
     }
 }
 
@@ -177,7 +178,12 @@ export class CenterCommand extends BoundsAwareViewportCommand {
         if (!Dimension.isValid(model.canvasBounds)) {
             return undefined;
         }
-        const zoom = (this.action.retainZoom && isViewport(model)) ? model.zoom : 1;
+        let zoom = 1;
+        if (this.action.retainZoom && isViewport(model)) {
+            zoom = model.zoom;
+        } else if (this.action.zoomScale) {
+            zoom = this.action.zoomScale;
+        }
         const c = Bounds.center(bounds);
         return {
             scroll: {


### PR DESCRIPTION
Added a `zoomScale` property to the `CenterAction` to explicitly set te zoom level when centering the view.

**how to test**
in the circlegraph example:
- add following new button to the `circlegraph.html` file
``` <button id="centerZoomed">center and zoom selection</button>```
-  add following code to the `standalone.ts` to execute the center action on click
```    
document.getElementById('centerZoomed')!.addEventListener('click', async () => {
    dispatcher.dispatch(CenterAction.create(graph.children.map(el => el.id), {animate: true, zoomScale: 2}))
});
```
now when clicking the button the center action is executed and zoom level is set to 2.