### PR TITLE
Improve extensibility of multi-injected keys

### DIFF
--- a/examples/circlegraph/src/di.config.ts
+++ b/examples/circlegraph/src/di.config.ts
@@ -33,7 +33,8 @@ export default (nodeCreator: (point?: Point)=>void) => {
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
         bind(NodeCreator).toConstantValue(nodeCreator);
-        bind(TYPES.MouseListener).to(DroppableMouseListener);
+        bind(DroppableMouseListener).toSelf().inSingletonScope();
+        bind(TYPES.MouseListener).toService(DroppableMouseListener);
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:circle', CircularNode, CircleNodeView);

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -42,7 +42,8 @@ export default (containerId: string) => {
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
         bind(TYPES.IPopupModelProvider).to(PopupModelProvider);
-        bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
+        bind(RevealNamedElementActionProvider).toSelf().inSingletonScope();
+        bind(TYPES.ICommandPaletteActionProvider).toService(RevealNamedElementActionProvider);
         bind(TYPES.ISnapper).to(CenterGridSnapper);
         bind(TYPES.IEditLabelValidator).to(ClassDiagramLabelValidator);
         bind(TYPES.IEditLabelValidationDecorator).to(ClassDiagramLabelValidationDecorator);

--- a/packages/sprotty/src/features/export/di.config.ts
+++ b/packages/sprotty/src/features/export/di.config.ts
@@ -23,7 +23,8 @@ import { configureCommand } from "../../base/commands/command-registration";
 const exportSvgModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(ExportSvgKeyListener).toSelf().inSingletonScope();
     bind(TYPES.KeyListener).toService(ExportSvgKeyListener);
-    bind(TYPES.HiddenVNodePostprocessor).to(ExportSvgPostprocessor).inSingletonScope();
+    bind(ExportSvgPostprocessor).toSelf().inSingletonScope();
+    bind(TYPES.HiddenVNodePostprocessor).toService(ExportSvgPostprocessor);
     configureCommand({ bind, isBound }, ExportSvgCommand);
     bind(TYPES.SvgExporter).to(SvgExporter).inSingletonScope();
 });

--- a/packages/sprotty/src/features/fade/di.config.ts
+++ b/packages/sprotty/src/features/fade/di.config.ts
@@ -19,7 +19,8 @@ import { TYPES } from "../../base/types";
 import { ElementFader } from "./fade";
 
 const fadeModule = new ContainerModule(bind => {
-    bind(TYPES.IVNodePostprocessor).to(ElementFader).inSingletonScope();
+    bind(ElementFader).toSelf().inSingletonScope();
+    bind(TYPES.IVNodePostprocessor).toService(ElementFader);
 });
 
 export default fadeModule;

--- a/packages/sprotty/src/features/hover/di.config.ts
+++ b/packages/sprotty/src/features/hover/di.config.ts
@@ -28,7 +28,8 @@ import { SetViewportCommand } from "../viewport/viewport";
 import { MoveCommand } from "../move/move";
 
 const hoverModule = new ContainerModule((bind, _unbind, isBound) => {
-    bind(TYPES.PopupVNodePostprocessor).to(PopupPositionUpdater).inSingletonScope();
+    bind(PopupPositionUpdater).toSelf().inSingletonScope();
+    bind(TYPES.PopupVNodePostprocessor).toService(PopupPositionUpdater);
     bind(HoverMouseListener).toSelf().inSingletonScope();
     bind(TYPES.MouseListener).toService(HoverMouseListener);
     bind(PopupHoverMouseListener).toSelf().inSingletonScope();

--- a/packages/sprotty/src/features/routing/di.config.ts
+++ b/packages/sprotty/src/features/routing/di.config.ts
@@ -33,21 +33,30 @@ const routingModule = new ContainerModule((bind, _unbind, isBound) => {
 
     bind(ManhattanEdgeRouter).toSelf().inSingletonScope();
     bind(TYPES.IEdgeRouter).toService(ManhattanEdgeRouter);
-    bind(TYPES.IAnchorComputer).to(ManhattanEllipticAnchor).inSingletonScope();
-    bind(TYPES.IAnchorComputer).to(ManhattanRectangularAnchor).inSingletonScope();
-    bind(TYPES.IAnchorComputer).to(ManhattanDiamondAnchor).inSingletonScope();
+    bind(ManhattanEllipticAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(ManhattanEllipticAnchor);
+    bind(ManhattanRectangularAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(ManhattanRectangularAnchor);
+    bind(ManhattanDiamondAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(ManhattanDiamondAnchor);
 
     bind(PolylineEdgeRouter).toSelf().inSingletonScope();
     bind(TYPES.IEdgeRouter).toService(PolylineEdgeRouter);
-    bind(TYPES.IAnchorComputer).to(EllipseAnchor);
-    bind(TYPES.IAnchorComputer).to(RectangleAnchor);
-    bind(TYPES.IAnchorComputer).to(DiamondAnchor);
+    bind(EllipseAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(EllipseAnchor);
+    bind(RectangleAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(RectangleAnchor);
+    bind(DiamondAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(DiamondAnchor);
 
     bind(BezierEdgeRouter).toSelf().inSingletonScope();
     bind(TYPES.IEdgeRouter).toService(BezierEdgeRouter);
-    bind(TYPES.IAnchorComputer).to(BezierEllipseAnchor);
-    bind(TYPES.IAnchorComputer).to(BezierRectangleAnchor);
-    bind(TYPES.IAnchorComputer).to(BezierDiamondAnchor);
+    bind(BezierEllipseAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(BezierEllipseAnchor);
+    bind(BezierRectangleAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(BezierRectangleAnchor);
+    bind(BezierDiamondAnchor).toSelf().inSingletonScope();
+    bind(TYPES.IAnchorComputer).toService(BezierDiamondAnchor);
 
     configureCommand({ bind, isBound }, AddRemoveBezierSegmentCommand);
 });


### PR DESCRIPTION
Double check the codebase and ensure that all all multi-injected classes are bound to self() in Singleton scope before binding them to the multi injection key 
Fixes #239