### PR TITLE
Updated scaledFont to account for decimals

### DIFF
--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -269,7 +269,7 @@ function getEditableLabels(contextElementIds: string[], root: Readonly<SModelRoo
 }
 
 function scaledFont(font: string, zoom: number): string {
-    return font.replace(/([0-9]+[.]?[0-9]*)/, (match) => {
+    return font.replace(/\d+(\.\d+)?/, (match) => {
         return String(Number.parseInt(match, 10) * zoom);
     });
 }

--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -269,7 +269,7 @@ function getEditableLabels(contextElementIds: string[], root: Readonly<SModelRoo
 }
 
 function scaledFont(font: string, zoom: number): string {
-    return font.replace(/([0-9]+)/, (match) => {
+    return font.replace(/([0-9]+[.]?[0-9]*)/, (match) => {
         return String(Number.parseInt(match, 10) * zoom);
     });
 }


### PR DESCRIPTION
The previous implementation was breaking with decimal numbers, which I talked about [in this discussion post](https://github.com/eclipse-glsp/glsp/discussions/971), so this is a potential fix to prevent this behavior in the future.