### PR TITLE
Fix font scaling in edit label UI extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,7 @@
         {
             "label": "Build Sprotty examples",
             "type": "shell",
-            "command": "yarn examples:build",
+            "command": "yarn --cwd examples build",
             "group": "build",
             "presentation": {
                 "focus": false,

--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -269,7 +269,7 @@ function getEditableLabels(contextElementIds: string[], root: Readonly<SModelRoo
 }
 
 function scaledFont(font: string, zoom: number): string {
-    return font.replace(/([0-9]+)/, (match) => {
+    return font.replace(/\d+(\.\d+)?/, (match) => {
         return String(Number.parseInt(match, 10) * zoom);
     });
 }


### PR DESCRIPTION
If the font size property is a number with decimals, the regular expression didn't account for the decimal place. This change enhances the regular expression to match also the numbers after the decimal point.

Initially raised in https://github.com/eclipse-sprotty/sprotty/pull/351

Also this change fixes the VS Code build task of this repository.

Change-Id: I9592518e533e5636e4f3a27319cbe96a5ec71ae1