### PR TITLE
Rename internal model classes with 'Impl' suffix

### DIFF
--- a/examples/circlegraph/src/di.config.ts
+++ b/examples/circlegraph/src/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,19 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Container, ContainerModule, injectable, inject } from "inversify";
+import { Container, ContainerModule, injectable, inject } from 'inversify';
 import {
     TYPES, configureViewerOptions, SGraphView, ConsoleLogger, LogLevel, loadDefaultModules,
-    LocalModelSource, CircularNode, configureModelElement, SGraph, SEdge, selectFeature, PolylineEdgeView, MouseListener, SModelElement
+    LocalModelSource, CircularNode, configureModelElement, SGraphImpl, SEdgeImpl, selectFeature,
+    PolylineEdgeView, MouseListener, SModelElementImpl
 } from 'sprotty';
-import { Action, Point } from "sprotty-protocol";
-import { CircleNodeView } from "./views";
+import { Action, Point } from 'sprotty-protocol';
+import { CircleNodeView } from './views';
 
 const NodeCreator = Symbol('NodeCreator');
 
 export default (nodeCreator: (point?: Point)=>void) => {
-    require("sprotty/css/sprotty.css");
-    require("../css/diagram.css");
+    require('sprotty/css/sprotty.css');
+    require('../css/diagram.css');
 
     const circlegraphModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
@@ -36,11 +37,13 @@ export default (nodeCreator: (point?: Point)=>void) => {
         bind(DroppableMouseListener).toSelf().inSingletonScope();
         bind(TYPES.MouseListener).toService(DroppableMouseListener);
         const context = { bind, unbind, isBound, rebind };
-        configureModelElement(context, 'graph', SGraph, SGraphView);
+
+        configureModelElement(context, 'graph', SGraphImpl, SGraphView);
         configureModelElement(context, 'node:circle', CircularNode, CircleNodeView);
-        configureModelElement(context, 'edge:straight', SEdge, PolylineEdgeView, {
+        configureModelElement(context, 'edge:straight', SEdgeImpl, PolylineEdgeView, {
             disable: [selectFeature]
         });
+
         configureViewerOptions(context, {
             needsClientLayout: false
         });
@@ -57,12 +60,12 @@ class DroppableMouseListener extends MouseListener {
 
     @inject(NodeCreator) nodeCreator: (point?: Point)=>void;
 
-    override dragOver(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override dragOver(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         event.preventDefault();
         return [];
     }
 
-    override drop(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override drop(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         this.nodeCreator({ x: event.offsetX, y:event.offsetY })
         return [];
     }

--- a/examples/circlegraph/src/standalone.ts
+++ b/examples/circlegraph/src/standalone.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,10 +15,10 @@
  ********************************************************************************/
 
 import {
-    TYPES, IActionDispatcher, ElementMove, MoveAction, LocalModelSource, getBasicType
+    TYPES, IActionDispatcher, ElementMove, MoveAction, LocalModelSource
 } from 'sprotty';
-import { Bounds, Point, SEdge, SelectAction, SGraph, SNode } from 'sprotty-protocol';
-import createContainer from "./di.config";
+import { Bounds, Point, SEdge, SelectAction, SGraph, SNode, getBasicType } from 'sprotty-protocol';
+import createContainer from './di.config';
 
 const NODE_SIZE = 60;
 

--- a/examples/circlegraph/src/views.tsx
+++ b/examples/circlegraph/src/views.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,15 +17,15 @@
 /** @jsx svg */
 import { svg } from 'sprotty/lib/lib/jsx';
 import { injectable } from 'inversify';
-import { VNode } from "snabbdom";
-import { RenderingContext, SNode, ShapeView } from 'sprotty';
+import { VNode } from 'snabbdom';
+import { RenderingContext, SNodeImpl, ShapeView } from 'sprotty';
 
 /**
  * A very simple example node consisting of a plain circle.
  */
 @injectable()
 export class CircleNodeView extends ShapeView {
-    render(node: SNode, context: RenderingContext): VNode | undefined {
+    render(node: SNodeImpl, context: RenderingContext): VNode | undefined {
         if (!this.isVisible(node, context)) {
             return undefined;
         }
@@ -40,7 +40,7 @@ export class CircleNodeView extends ShapeView {
         </g>;
     }
 
-    protected getRadius(node: SNode): number {
+    protected getRadius(node: SNodeImpl): number {
         const d = Math.min(node.size.width, node.size.height);
         return d > 0 ? d / 2 : 0;
     }

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,29 +14,29 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import '@vscode/codicons/dist/codicon.css';
-import { Container, ContainerModule } from "inversify";
+import { Container, ContainerModule } from 'inversify';
 import {
     TYPES, configureViewerOptions, SGraphView, SLabelView, SCompartmentView, JumpingPolylineEdgeView,
     ConsoleLogger, LogLevel, loadDefaultModules, HtmlRootView, PreRenderedView, ExpandButtonView,
-    SRoutingHandleView, PreRenderedElement, HtmlRoot, SGraph, configureModelElement, SLabel,
-    SCompartment, SEdge, SButton, SRoutingHandle, RevealNamedElementActionProvider,
+    SRoutingHandleView, PreRenderedElementImpl, HtmlRootImpl, SGraphImpl, configureModelElement, SLabelImpl,
+    SCompartmentImpl, SEdgeImpl, SButtonImpl, SRoutingHandleImpl, RevealNamedElementActionProvider,
     CenterGridSnapper, expandFeature, nameFeature, withEditLabelFeature, editLabelFeature,
     RectangularNode, BezierCurveEdgeView, SBezierCreateHandleView, SBezierControlHandleView
 } from 'sprotty';
-import edgeIntersectionModule from "sprotty/lib/features/edge-intersection/di.config";
+import edgeIntersectionModule from 'sprotty/lib/features/edge-intersection/di.config';
 import { BezierMouseListener } from 'sprotty/lib/features/routing/bezier-edge-router';
 import { ClassDiagramLabelValidationDecorator, ClassDiagramLabelValidator } from './label-validation';
 import { ClassContextMenuItemProvider, ClassContextMenuService } from './menu';
-import { ClassLabel, ClassNode, Icon, PropertyLabel } from "./model";
+import { ClassLabel, ClassNode, Icon, PropertyLabel } from './model';
 import { ClassDiagramModelSource } from './model-source';
-import { PopupModelProvider } from "./popup";
-import { IconView, NodeView } from "./views";
+import { PopupModelProvider } from './popup';
+import { IconView, NodeView } from './views';
 
 export default (containerId: string) => {
-    require("sprotty/css/sprotty.css");
-    require("sprotty/css/command-palette.css");
-    require("sprotty/css/edit-label.css");
-    require("../css/diagram.css");
+    require('sprotty/css/sprotty.css');
+    require('sprotty/css/command-palette.css');
+    require('sprotty/css/edit-label.css');
+    require('../css/diagram.css');
 
     const classDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         bind(TYPES.ModelSource).to(ClassDiagramModelSource).inSingletonScope();
@@ -54,7 +54,7 @@ export default (containerId: string) => {
         bind(TYPES.IContextMenuItemProvider).to(ClassContextMenuItemProvider);
 
         const context = { bind, unbind, isBound, rebind };
-        configureModelElement(context, 'graph', SGraph, SGraphView);
+        configureModelElement(context, 'graph', SGraphImpl, SGraphView);
         configureModelElement(context, 'node:package', RectangularNode, NodeView);
         configureModelElement(context, 'node:class', ClassNode, NodeView, {
             enable: [expandFeature, nameFeature, withEditLabelFeature]
@@ -65,21 +65,21 @@ export default (containerId: string) => {
         configureModelElement(context, 'label:text', PropertyLabel, SLabelView, {
             enable: [editLabelFeature]
         });
-        configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
-        configureModelElement(context, 'comp:header', SCompartment, SCompartmentView);
-        configureModelElement(context, 'comp:pkgcontent', SCompartment, SCompartmentView);
+        configureModelElement(context, 'comp:comp', SCompartmentImpl, SCompartmentView);
+        configureModelElement(context, 'comp:header', SCompartmentImpl, SCompartmentView);
+        configureModelElement(context, 'comp:pkgcontent', SCompartmentImpl, SCompartmentView);
         configureModelElement(context, 'icon', Icon, IconView);
-        configureModelElement(context, 'label:icon', SLabel, SLabelView);
-        configureModelElement(context, 'edge:straight', SEdge, JumpingPolylineEdgeView);
-        configureModelElement(context, 'edge:bezier', SEdge, BezierCurveEdgeView);
-        configureModelElement(context, 'html', HtmlRoot, HtmlRootView);
-        configureModelElement(context, 'pre-rendered', PreRenderedElement, PreRenderedView);
-        configureModelElement(context, 'button:expand', SButton, ExpandButtonView);
-        configureModelElement(context, 'routing-point', SRoutingHandle, SRoutingHandleView);
-        configureModelElement(context, 'volatile-routing-point', SRoutingHandle, SRoutingHandleView);
-        configureModelElement(context, 'bezier-create-routing-point', SRoutingHandle, SBezierCreateHandleView);
-        configureModelElement(context, 'bezier-remove-routing-point', SRoutingHandle, SBezierCreateHandleView);
-        configureModelElement(context, 'bezier-routing-point', SRoutingHandle, SBezierControlHandleView);
+        configureModelElement(context, 'label:icon', SLabelImpl, SLabelView);
+        configureModelElement(context, 'edge:straight', SEdgeImpl, JumpingPolylineEdgeView);
+        configureModelElement(context, 'edge:bezier', SEdgeImpl, BezierCurveEdgeView);
+        configureModelElement(context, 'html', HtmlRootImpl, HtmlRootView);
+        configureModelElement(context, 'pre-rendered', PreRenderedElementImpl, PreRenderedView);
+        configureModelElement(context, 'button:expand', SButtonImpl, ExpandButtonView);
+        configureModelElement(context, 'routing-point', SRoutingHandleImpl, SRoutingHandleView);
+        configureModelElement(context, 'volatile-routing-point', SRoutingHandleImpl, SRoutingHandleView);
+        configureModelElement(context, 'bezier-create-routing-point', SRoutingHandleImpl, SBezierCreateHandleView);
+        configureModelElement(context, 'bezier-remove-routing-point', SRoutingHandleImpl, SBezierCreateHandleView);
+        configureModelElement(context, 'bezier-routing-point', SRoutingHandleImpl, SBezierControlHandleView);
 
 
         configureViewerOptions(context, {

--- a/examples/classdiagram/src/label-validation.ts
+++ b/examples/classdiagram/src/label-validation.ts
@@ -13,14 +13,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+
+import { injectable } from 'inversify';
 import {
-    IEditLabelValidator, EditableLabel, SModelElement, EditLabelValidationResult, Severity, IEditLabelValidationDecorator
+    IEditLabelValidator, EditableLabel, SModelElementImpl, EditLabelValidationResult, Severity, IEditLabelValidationDecorator
 } from 'sprotty';
-import { injectable } from "inversify";
 
 @injectable()
 export class ClassDiagramLabelValidator implements IEditLabelValidator {
-    async validate(value: string, label: EditableLabel & SModelElement): Promise<EditLabelValidationResult> {
+    async validate(value: string, label: EditableLabel & SModelElementImpl): Promise<EditLabelValidationResult> {
         if (value.length < 1) {
             return {
                 severity: <Severity>'error',

--- a/examples/classdiagram/src/menu.ts
+++ b/examples/classdiagram/src/menu.ts
@@ -14,9 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from "inversify";
-import { Anchor, DeleteElementAction, EMPTY_ROOT, GetSelectionAction, IActionDispatcher, IContextMenuItemProvider, IContextMenuService, LabeledAction, MenuItem, RequestExportSvgAction, SelectionResult, SModelRoot, TYPES, ViewerOptions } from "sprotty";
-import { CenterAction, FitToScreenAction, Point, SetPopupModelAction } from "sprotty-protocol";
+import { inject, injectable } from 'inversify';
+import {
+    Anchor, DeleteElementAction, EMPTY_ROOT, GetSelectionAction, IActionDispatcher,
+    IContextMenuItemProvider, IContextMenuService, LabeledAction, MenuItem,
+    RequestExportSvgAction, SelectionResult, SModelRootImpl, TYPES, ViewerOptions
+} from 'sprotty';
+import { CenterAction, FitToScreenAction, Point, SetPopupModelAction } from 'sprotty-protocol';
 
 @injectable()
 export class ClassContextMenuService implements IContextMenuService {
@@ -72,7 +76,7 @@ export class ClassContextMenuItemProvider implements IContextMenuItemProvider {
 
     @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
 
-    async getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point | undefined): Promise<LabeledAction[]> {
+    async getItems(root: Readonly<SModelRootImpl>, lastMousePosition?: Point | undefined): Promise<LabeledAction[]> {
         const selectionResult = await this.actionDispatcher.request<SelectionResult>(GetSelectionAction.create())
         return [
             new LabeledAction('Fit Diagram to Screen', [FitToScreenAction.create(root.children.map(child => child.id))]),

--- a/examples/classdiagram/src/model.ts
+++ b/examples/classdiagram/src/model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import {
-    SShapeElement, Expandable, RectangularNode, Nameable, SLabel, WithEditableLabel, isEditableLabel,
+    SShapeElementImpl, Expandable, RectangularNode, Nameable, SLabelImpl, WithEditableLabel, isEditableLabel,
     boundsFeature, layoutContainerFeature, layoutableChildFeature, fadeFeature
 } from 'sprotty';
 
@@ -41,10 +41,10 @@ export class ClassNode extends RectangularNode implements Expandable, Nameable, 
     }
 }
 
-export class ClassLabel extends SLabel { }
-export class PropertyLabel extends SLabel { }
+export class ClassLabel extends SLabelImpl { }
+export class PropertyLabel extends SLabelImpl { }
 
-export class Icon extends SShapeElement {
+export class Icon extends SShapeElementImpl {
     static readonly DEFAULT_FEATURES = [boundsFeature, layoutContainerFeature, layoutableChildFeature, fadeFeature];
 
     override size = {

--- a/examples/classdiagram/src/popup.ts
+++ b/examples/classdiagram/src/popup.ts
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from "inversify";
+import { injectable, inject } from 'inversify';
 import {
     TYPES, IModelFactory, IPopupModelProvider
 } from 'sprotty';
-import { PreRenderedElement, RequestPopupModelAction, SModelElement, SModelRoot } from "sprotty-protocol";
-import { ClassNode } from "./model";
+import { PreRenderedElement, RequestPopupModelAction, SModelElement, SModelRoot } from 'sprotty-protocol';
+import { ClassNode } from './model';
 
 @injectable()
 export class PopupModelProvider implements IPopupModelProvider {

--- a/examples/classdiagram/src/standalone.ts
+++ b/examples/classdiagram/src/standalone.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import createContainer from "./di.config";
+import createContainer from './di.config';
 import { TYPES, LocalModelSource } from 'sprotty';
 
 export default function runClassDiagram() {

--- a/examples/classdiagram/src/views.tsx
+++ b/examples/classdiagram/src/views.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,14 +17,14 @@
 /** @jsx svg */
 import { svg } from 'sprotty/lib/lib/jsx';
 
-import { RenderingContext, IView, RectangularNodeView, SNode, IViewArgs } from 'sprotty';
-import { VNode } from "snabbdom";
+import { RenderingContext, IView, RectangularNodeView, SNodeImpl, IViewArgs } from 'sprotty';
+import { VNode } from 'snabbdom';
 import { Icon } from './model';
 import { injectable } from 'inversify';
 
 @injectable()
 export class NodeView extends RectangularNodeView {
-    override render(node: Readonly<SNode>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
+    override render(node: Readonly<SNodeImpl>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
         if (!this.isVisible(node, context)) {
             return undefined;
         }
@@ -33,7 +33,7 @@ export class NodeView extends RectangularNodeView {
                   class-node-package={node.type === 'node:package'}
                   class-node-class={node.type === 'node:class'}
                   class-mouseover={node.hoverFeedback} class-selected={node.selected}
-                  x="0" y="0" width={Math.max(node.size.width, 0)} height={Math.max(node.size.height, 0)}></rect>
+                  x='0' y='0' width={Math.max(node.size.width, 0)} height={Math.max(node.size.height, 0)}></rect>
             {context.renderChildren(node)}
         </g>;
     }

--- a/examples/multicore/src/chipmodel-factory.ts
+++ b/examples/multicore/src/chipmodel-factory.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,22 +15,22 @@
  ********************************************************************************/
 
 import {
-    SGraphFactory, SChildElement, SModelRoot, SParentElement, getBasicType, PreRenderedElement, HtmlRoot,
+    SGraphFactory, SChildElementImpl, SModelRootImpl, SParentElementImpl, PreRenderedElementImpl, HtmlRootImpl,
     createFeatureSet, Direction
 } from 'sprotty';
 import {
     SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema, HtmlRoot as HtmlRootSchema,
-    PreRenderedElement as PreRenderedElementSchema
+    PreRenderedElement as PreRenderedElementSchema, getBasicType
 } from 'sprotty-protocol';
 import {
     Channel, ChannelSchema, Core, CoreSchema, Crossbar, CrossbarSchema, Processor, ProcessorSchema
-} from "./chipmodel";
-import { CORE_WIDTH, CORE_DISTANCE } from "./views";
+} from './chipmodel';
+import { CORE_WIDTH, CORE_DISTANCE } from './views';
 
 
 export class ChipModelFactory extends SGraphFactory {
 
-    override createElement(schema: SModelElementSchema, parent?: SParentElement): SChildElement {
+    override createElement(schema: SModelElementSchema, parent?: SParentElementImpl): SChildElementImpl {
         try {
             if (this.isCoreSchema(schema)) {
                 this.validate(schema, parent);
@@ -51,7 +51,7 @@ export class ChipModelFactory extends SGraphFactory {
             } else if (this.isCrossbarSchema(schema)) {
                 return this.initializeChild(new Crossbar(), schema, parent);
             } else if (this.isPreRenderedSchema(schema)) {
-                return this.initializeChild(new PreRenderedElement(), schema, parent);
+                return this.initializeChild(new PreRenderedElementImpl(), schema, parent);
             }
         } catch (e) {
             console.error(e.message);
@@ -59,19 +59,19 @@ export class ChipModelFactory extends SGraphFactory {
         return super.createElement(schema, parent);
     }
 
-    override createRoot(schema: SModelRootSchema): SModelRoot {
+    override createRoot(schema: SModelRootSchema): SModelRootImpl {
         if (this.isProcessorSchema(schema)) {
             const processor = this.initializeRoot(new Processor(), schema);
             processor.features = createFeatureSet(Processor.DEFAULT_FEATURES);
             return processor;
         } else if (this.isHtmlRootSchema(schema)) {
-            return this.initializeRoot(new HtmlRoot(), schema);
+            return this.initializeRoot(new HtmlRootImpl(), schema);
         } else {
             return super.createRoot(schema);
         }
     }
 
-    private validate(coreOrChannel: CoreSchema | ChannelSchema, processor?: SParentElement) {
+    private validate(coreOrChannel: CoreSchema | ChannelSchema, processor?: SParentElementImpl) {
         if (processor) {
             if (!(processor instanceof Processor))
                 throw new Error('Parent model element must be a Processor');

--- a/examples/multicore/src/chipmodel.ts
+++ b/examples/multicore/src/chipmodel.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,11 +15,11 @@
  ********************************************************************************/
 
 import {
-    SShapeElement, SChildElement, Direction, BoundsAware, boundsFeature, Fadeable, fadeFeature,
+    SShapeElementImpl, SChildElementImpl, Direction, BoundsAware, boundsFeature, Fadeable, fadeFeature,
     layoutContainerFeature, LayoutContainer, Selectable, selectFeature,
-    ViewportRootElement, hoverFeedbackFeature, Hoverable, popupFeature, JsonMap
+    ViewportRootElement, hoverFeedbackFeature, Hoverable, popupFeature
 } from 'sprotty';
-import { Bounds, SModelElement, SModelRoot } from 'sprotty-protocol';
+import { Bounds, SModelElement, SModelRoot, JsonMap } from 'sprotty-protocol';
 import { CORE_DISTANCE, CORE_WIDTH } from "./views";
 
 export interface ProcessorSchema extends SModelRoot {
@@ -59,7 +59,7 @@ export interface CoreSchema extends SModelElement {
     children: SModelElement[]
 }
 
-export class Core extends SShapeElement implements Selectable, Fadeable, Hoverable, LayoutContainer {
+export class Core extends SShapeElementImpl implements Selectable, Fadeable, Hoverable, LayoutContainer {
     static readonly DEFAULT_FEATURES = [selectFeature, fadeFeature, layoutContainerFeature,
         hoverFeedbackFeature, popupFeature];
 
@@ -80,7 +80,7 @@ export interface CrossbarSchema extends SModelElement {
     load: number
 }
 
-export class Crossbar extends SChildElement {
+export class Crossbar extends SChildElementImpl {
     direction: Direction;
     load: number = 0;
 }
@@ -93,7 +93,7 @@ export interface ChannelSchema extends SModelElement {
     load: number
 }
 
-export class Channel extends SChildElement implements Selectable {
+export class Channel extends SChildElementImpl implements Selectable {
     static readonly DEFAULT_FEATURES = [selectFeature];
 
     column: number = 0;

--- a/examples/multicore/src/di.config.ts
+++ b/examples/multicore/src/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,14 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Container, ContainerModule } from "inversify";
+import { Container, ContainerModule } from 'inversify';
 import {
     SCompartmentView, SLabelView, TYPES, configureViewerOptions, ConsoleLogger, LogLevel,
     loadDefaultModules, LocalModelSource, HtmlRootView, PreRenderedView, SvgExporter,
     configureView
 } from 'sprotty';
-import { ChipModelFactory } from "./chipmodel-factory";
-import { ProcessorView, CoreView, CrossbarView, ChannelView, SimpleCoreView } from "./views";
+import { ChipModelFactory } from './chipmodel-factory';
+import { ProcessorView, CoreView, CrossbarView, ChannelView, SimpleCoreView } from './views';
 
 class FilteringSvgExporter extends SvgExporter {
     isExported(styleSheet: CSSStyleSheet): boolean {
@@ -34,8 +34,8 @@ class FilteringSvgExporter extends SvgExporter {
 }
 
 export default () => {
-    require("sprotty/css/sprotty.css");
-    require("../css/diagram.css");
+    require('sprotty/css/sprotty.css');
+    require('../css/diagram.css');
 
     const multicoreModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();

--- a/examples/multicore/src/multicore.ts
+++ b/examples/multicore/src/multicore.ts
@@ -19,7 +19,7 @@ import { SLabel, UpdateModelAction } from 'sprotty-protocol';
 import {
     ChannelSchema, CoreSchema, CrossbarSchema, ProcessorSchema
 } from './chipmodel';
-import createContainer from "./di.config";
+import createContainer from './di.config';
 
 export default function runMulticore() {
     const container = createContainer();

--- a/examples/random-graph-distributed/src/di.config.ts
+++ b/examples/random-graph-distributed/src/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2022 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,8 +17,8 @@
 import { Container, ContainerModule } from 'inversify';
 import {
     TYPES, configureViewerOptions, SGraphView, SLabelView, ConsoleLogger, LogLevel,
-    loadDefaultModules, SNode, SEdge, SLabel, configureModelElement,
-    SGraph, RectangularNodeView, PolylineEdgeView, WebSocketDiagramServerProxy
+    loadDefaultModules, SNodeImpl, SEdgeImpl, SLabelImpl, configureModelElement,
+    SGraphImpl, RectangularNodeView, PolylineEdgeView, WebSocketDiagramServerProxy
 } from 'sprotty';
 
 export default (containerId: string) => {
@@ -31,10 +31,10 @@ export default (containerId: string) => {
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
 
         const context = { bind, unbind, isBound, rebind };
-        configureModelElement(container, 'graph', SGraph, SGraphView);
-        configureModelElement(container, 'node', SNode, RectangularNodeView);
-        configureModelElement(container, 'edge', SEdge, PolylineEdgeView);
-        configureModelElement(container, 'label', SLabel, SLabelView);
+        configureModelElement(container, 'graph', SGraphImpl, SGraphView);
+        configureModelElement(container, 'node', SNodeImpl, RectangularNodeView);
+        configureModelElement(container, 'edge', SEdgeImpl, PolylineEdgeView);
+        configureModelElement(container, 'label', SLabelImpl, SLabelView);
 
         configureViewerOptions(context, {
             needsClientLayout: false,

--- a/examples/random-graph/src/di.config.ts
+++ b/examples/random-graph/src/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2021 TypeFox and others.
+ * Copyright (c) 2017-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,8 +18,8 @@ import { Container, ContainerModule } from 'inversify';
 import ElkConstructor from 'elkjs/lib/elk.bundled';
 import {
     TYPES, configureViewerOptions, SGraphView, SLabelView, ConsoleLogger, LogLevel,
-    loadDefaultModules, LocalModelSource, SNode, SEdge, SLabel, configureModelElement,
-    SGraph, RectangularNodeView, edgeIntersectionModule, PolylineEdgeViewWithGapsOnIntersections
+    loadDefaultModules, LocalModelSource, SNodeImpl, SEdgeImpl, SLabelImpl, configureModelElement,
+    SGraphImpl, RectangularNodeView, edgeIntersectionModule, PolylineEdgeViewWithGapsOnIntersections
 } from 'sprotty';
 import { ElkFactory, ElkLayoutEngine, elkLayoutModule } from 'sprotty-elk/lib/inversify';
 
@@ -39,10 +39,10 @@ export default (containerId: string) => {
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
 
         const context = { bind, unbind, isBound, rebind };
-        configureModelElement(container, 'graph', SGraph, SGraphView);
-        configureModelElement(container, 'node', SNode, RectangularNodeView);
-        configureModelElement(container, 'edge', SEdge, PolylineEdgeViewWithGapsOnIntersections);
-        configureModelElement(container, 'label', SLabel, SLabelView);
+        configureModelElement(container, 'graph', SGraphImpl, SGraphView);
+        configureModelElement(container, 'node', SNodeImpl, RectangularNodeView);
+        configureModelElement(container, 'edge', SEdgeImpl, PolylineEdgeViewWithGapsOnIntersections);
+        configureModelElement(container, 'label', SLabelImpl, SLabelView);
 
         configureViewerOptions(context, {
             needsClientLayout: true,

--- a/packages/generator-sprotty/sprotty-local-template/src/di.config.ts
+++ b/packages/generator-sprotty/sprotty-local-template/src/di.config.ts
@@ -1,29 +1,31 @@
-import { Container, ContainerModule } from "inversify";
-import { configureModelElement, configureViewerOptions, ConsoleLogger, edgeIntersectionModule, loadDefaultModules, LocalModelSource, LogLevel, PolylineEdgeView, RectangularNode, SEdge, SGraph, SGraphView, TYPES } from "sprotty";
-import { TaskNodeView } from "./views";
+import { Container, ContainerModule } from 'inversify';
+import {
+    configureModelElement, configureViewerOptions, ConsoleLogger, edgeIntersectionModule,
+    loadDefaultModules, LocalModelSource, LogLevel, PolylineEdgeView, RectangularNode,
+    SEdgeImpl, SGraphImpl, SGraphView, TYPES
+} from 'sprotty';
+import { TaskNodeView } from './views';
 
 export default (containerId: string) => {
-
-    const ASCETExamleModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    const myModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
         const context = { bind, unbind, isBound, rebind };
-        configureModelElement(context, 'graph', SGraph, SGraphView);
+
+        configureModelElement(context, 'graph', SGraphImpl, SGraphView);
         configureModelElement(context, 'task', RectangularNode, TaskNodeView);
-        configureModelElement(context, 'edge', SEdge, PolylineEdgeView);
+        configureModelElement(context, 'edge', SEdgeImpl, PolylineEdgeView);
 
         configureViewerOptions(context, {
             needsClientLayout: false,
             baseDiv: containerId
         });
-
     });
 
     const container = new Container();
     loadDefaultModules(container);
-    container.load(ASCETExamleModule);
+    container.load(myModule);
     container.load(edgeIntersectionModule)
     return container;
-
 }

--- a/packages/generator-sprotty/sprotty-local-template/src/index.ts
+++ b/packages/generator-sprotty/sprotty-local-template/src/index.ts
@@ -1,7 +1,7 @@
-import 'reflect-metadata'
+import 'reflect-metadata';
 
-import { LocalModelSource, TYPES } from 'sprotty'
-import createContainer from './di.config'
+import { LocalModelSource, TYPES } from 'sprotty';
+import createContainer from './di.config';
 import { graph } from './model-source';
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/packages/generator-sprotty/sprotty-local-template/src/model-source.ts
+++ b/packages/generator-sprotty/sprotty-local-template/src/model-source.ts
@@ -1,5 +1,5 @@
-import { SEdge, SGraph, SNode } from "sprotty-protocol";
-import { TaskNode } from "./model";
+import { SEdge, SGraph, SNode } from 'sprotty-protocol';
+import { TaskNode } from './model';
 
 export const graph: SGraph = {
     type: 'graph',

--- a/packages/generator-sprotty/sprotty-local-template/src/model.ts
+++ b/packages/generator-sprotty/sprotty-local-template/src/model.ts
@@ -1,4 +1,4 @@
-import { SNode } from "sprotty-protocol"
+import { SNode } from 'sprotty-protocol';
 
 export interface TaskNode extends SNode {
     name: string;

--- a/packages/generator-sprotty/sprotty-local-template/src/views.tsx
+++ b/packages/generator-sprotty/sprotty-local-template/src/views.tsx
@@ -2,12 +2,12 @@
 import { svg } from 'sprotty/lib/lib/jsx';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { IView, RenderingContext, SNode } from 'sprotty';
+import { IView, RenderingContext, SNodeImpl } from 'sprotty';
 import { TaskNode } from './model';
 
 @injectable()
 export class TaskNodeView implements IView {
-    render(node: Readonly<SNode & TaskNode>, context: RenderingContext): VNode {
+    render(node: Readonly<SNodeImpl & TaskNode>, context: RenderingContext): VNode {
         return <g>
             <rect class-sprotty-node={true} class-task={true}
                 class-running={node.isRunning}

--- a/packages/sprotty/src/base/animations/animation.ts
+++ b/packages/sprotty/src/base/animations/animation.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { CommandExecutionContext } from "../commands/command";
-import { SModelRoot } from "../model/smodel";
+import { SModelRootImpl } from "../model/smodel";
 import { easeInOut } from "./easing";
 
 /**
@@ -27,9 +27,9 @@ export abstract class Animation {
     constructor(protected context: CommandExecutionContext, protected ease: (x: number) => number = easeInOut) {
     }
 
-    start(): Promise<SModelRoot> {
-        return new Promise<SModelRoot>(
-            (resolve: (model: SModelRoot) => void, reject: (model: SModelRoot) => void) => {
+    start(): Promise<SModelRootImpl> {
+        return new Promise<SModelRootImpl>(
+            (resolve: (model: SModelRootImpl) => void, reject: (model: SModelRootImpl) => void) => {
                 let start: number | undefined = undefined;
                 let frames = 0;
                 const lambda = (time: number) => {
@@ -67,12 +67,12 @@ export abstract class Animation {
      * @param t varies between 0 (start of animation) and 1 (end of animation)
      * @param context
      */
-    abstract tween(t: number, context: CommandExecutionContext): SModelRoot;
+    abstract tween(t: number, context: CommandExecutionContext): SModelRootImpl;
 }
 
 export class CompoundAnimation extends Animation {
 
-    constructor(protected model: SModelRoot,
+    constructor(protected model: SModelRootImpl,
                 protected override context: CommandExecutionContext,
                 public components: Animation[] = [],
                 protected override ease: (x: number) => number = easeInOut) {
@@ -84,7 +84,7 @@ export class CompoundAnimation extends Animation {
         return this;
     }
 
-    tween(t: number, context: CommandExecutionContext): SModelRoot {
+    tween(t: number, context: CommandExecutionContext): SModelRootImpl {
         for (const a of this.components) {
             a.tween(t, context);
         }

--- a/packages/sprotty/src/base/commands/command.ts
+++ b/packages/sprotty/src/base/commands/command.ts
@@ -18,7 +18,7 @@ import { injectable } from "inversify";
 import { Action } from "sprotty-protocol/lib/actions";
 import { ILogger } from "../../utils/logging";
 import { AnimationFrameSyncer } from "../animations/animation-frame-syncer";
-import { SModelRoot } from "../model/smodel";
+import { SModelRootImpl } from "../model/smodel";
 import { IModelFactory } from "../model/smodel-factory";
 import { IViewer } from "../views/viewer";
 
@@ -59,7 +59,7 @@ export interface ICommand {
  * chaining, it is essential that a command does not make any assumption
  * on the state of the model before execute() is called.
  */
-export type CommandReturn = SModelRoot | Promise<SModelRoot> | CommandResult;
+export type CommandReturn = SModelRootImpl | Promise<SModelRootImpl> | CommandResult;
 
 /**
  * The `CommandResult` allows to specify whether the model has changed
@@ -67,7 +67,7 @@ export type CommandReturn = SModelRoot | Promise<SModelRoot> | CommandResult;
  * an action is given, it is passed to the viewer in order to link any
  * subsequent response action to the original request.
  */
-export type CommandResult = { model: SModelRoot, modelChanged: boolean, cause?: Action };
+export type CommandResult = { model: SModelRootImpl, modelChanged: boolean, cause?: Action };
 
 /**
  * Base class for all commands.
@@ -133,7 +133,7 @@ export abstract class MergeableCommand extends Command {
  */
 @injectable()
 export abstract class HiddenCommand extends Command {
-    abstract override execute(context: CommandExecutionContext): SModelRoot | CommandResult;
+    abstract override execute(context: CommandExecutionContext): SModelRootImpl | CommandResult;
 
     undo(context: CommandExecutionContext): CommandReturn {
         context.logger.error(this, 'Cannot undo a hidden command');
@@ -179,7 +179,7 @@ export abstract class ResetCommand extends Command {
  */
 export interface CommandExecutionContext {
     /** The current Sprotty model (i.e. the main model that is visible to the user) */
-    root: SModelRoot
+    root: SModelRootImpl
 
     /** Used to turn sprotty schema elements (e.g. from the action) into model elements */
     modelFactory: IModelFactory

--- a/packages/sprotty/src/base/features/initialize-canvas.ts
+++ b/packages/sprotty/src/base/features/initialize-canvas.ts
@@ -21,7 +21,7 @@ import { almostEquals, Bounds, Dimension } from "sprotty-protocol/lib/utils/geom
 import { TYPES } from "../types";
 import { IActionDispatcher } from '../actions/action-dispatcher';
 import { IVNodePostprocessor } from "../views/vnode-postprocessor";
-import { SModelElement, SModelRoot } from "../model/smodel";
+import { SModelElementImpl, SModelRootImpl } from "../model/smodel";
 import { SystemCommand, CommandExecutionContext, CommandReturn } from '../commands/command';
 import { getWindowScroll } from "../../utils/browser";
 
@@ -33,12 +33,12 @@ import { getWindowScroll } from "../../utils/browser";
 @injectable()
 export class CanvasBoundsInitializer implements IVNodePostprocessor {
 
-    protected rootAndVnode: [SModelRoot, VNode] | undefined;
+    protected rootAndVnode: [SModelRootImpl, VNode] | undefined;
 
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
-        if (element instanceof SModelRoot && !Dimension.isValid(element.canvasBounds)) {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
+        if (element instanceof SModelRootImpl && !Dimension.isValid(element.canvasBounds)) {
             this.rootAndVnode = [element, vnode];
         }
         return vnode;

--- a/packages/sprotty/src/base/features/set-model.ts
+++ b/packages/sprotty/src/base/features/set-model.ts
@@ -22,7 +22,7 @@ import {
 import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { JsonPrimitive } from "sprotty-protocol/lib/utils/json";
 import { CommandExecutionContext, ResetCommand } from "../commands/command";
-import { SModelRoot } from "../model/smodel";
+import { SModelRootImpl } from "../model/smodel";
 import { TYPES } from "../types";
 import { InitializeCanvasBoundsCommand } from './initialize-canvas';
 
@@ -63,24 +63,24 @@ export class SetModelAction implements ResponseAction, ProtocolSetModelAction {
 export class SetModelCommand extends ResetCommand {
     static readonly KIND = ProtocolSetModelAction.KIND;
 
-    oldRoot: SModelRoot;
-    newRoot: SModelRoot;
+    oldRoot: SModelRootImpl;
+    newRoot: SModelRootImpl;
 
     constructor(@inject(TYPES.Action) protected readonly action: ProtocolSetModelAction) {
         super();
     }
 
-    execute(context: CommandExecutionContext): SModelRoot {
+    execute(context: CommandExecutionContext): SModelRootImpl {
         this.oldRoot = context.modelFactory.createRoot(context.root);
         this.newRoot = context.modelFactory.createRoot(this.action.newRoot);
         return this.newRoot;
     }
 
-    undo(context: CommandExecutionContext): SModelRoot {
+    undo(context: CommandExecutionContext): SModelRootImpl {
         return this.oldRoot;
     }
 
-    redo(context: CommandExecutionContext): SModelRoot {
+    redo(context: CommandExecutionContext): SModelRootImpl {
         return this.newRoot;
     }
 

--- a/packages/sprotty/src/base/tool-manager/tool-manager.ts
+++ b/packages/sprotty/src/base/tool-manager/tool-manager.ts
@@ -20,7 +20,7 @@ import { EnableDefaultToolsAction, EnableToolsAction, Tool } from "./tool";
 import { IActionHandler } from "../actions/action-handler";
 import { ICommand } from "../commands/command";
 import { KeyListener } from "../views/key-tool";
-import { SModelElement } from "../model/smodel";
+import { SModelElementImpl } from "../model/smodel";
 import { matchesKeystroke } from "../../utils/keyboard";
 
 /**
@@ -137,7 +137,7 @@ export class ToolManagerActionHandler implements IActionHandler {
 
 @injectable()
 export class DefaultToolsEnablingKeyListener extends KeyListener {
-    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'Escape')) {
             return [EnableDefaultToolsAction.create()];
         }

--- a/packages/sprotty/src/base/ui-extensions/ui-extension.ts
+++ b/packages/sprotty/src/base/ui-extensions/ui-extension.ts
@@ -16,7 +16,7 @@
 import { inject, injectable } from "inversify";
 import { hasOwnProperty } from "sprotty-protocol";
 import { ILogger } from "../../utils/logging";
-import { SModelRoot } from "../model/smodel";
+import { SModelRootImpl } from "../model/smodel";
 import { TYPES } from "../types";
 import { ViewerOptions } from "../views/viewer-options";
 
@@ -25,7 +25,7 @@ import { ViewerOptions } from "../views/viewer-options";
  */
 export interface IUIExtension {
     id(): string;
-    show(root: Readonly<SModelRoot>, ...contextElementIds: string[]): void;
+    show(root: Readonly<SModelRootImpl>, ...contextElementIds: string[]): void;
     hide(): void;
     enableOnStartup?: boolean
 }
@@ -50,7 +50,7 @@ export abstract class AbstractUIExtension implements IUIExtension {
     abstract id(): string;
     abstract containerClass(): string;
 
-    show(root: Readonly<SModelRoot>, ...contextElementIds: string[]): void {
+    show(root: Readonly<SModelRootImpl>, ...contextElementIds: string[]): void {
         this.activeElement = document.activeElement;
         if (!this.containerElement) {
             if (!this.initialize()) return;
@@ -115,7 +115,7 @@ export abstract class AbstractUIExtension implements IUIExtension {
      * `containerElement`, add or remove elements, etc. depending on the specified `root`
      * or `contextElementIds`.
      */
-    protected onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRoot>, ...contextElementIds: string[]): void {
+    protected onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRootImpl>, ...contextElementIds: string[]): void {
         // default: do nothing
     }
 

--- a/packages/sprotty/src/base/views/css-class-postprocessor.ts
+++ b/packages/sprotty/src/base/views/css-class-postprocessor.ts
@@ -17,13 +17,13 @@
 import { IVNodePostprocessor } from "./vnode-postprocessor";
 import { VNode } from "snabbdom";
 import { getSubType } from 'sprotty-protocol/lib/utils/model-utils';
-import { SModelElement } from "../model/smodel";
+import { SModelElementImpl } from "../model/smodel";
 import { setClass } from "./vnode-utils";
 import { injectable } from "inversify";
 
 @injectable()
 export class CssClassPostprocessor implements IVNodePostprocessor {
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         if (element.cssClasses) {
             for (const cssClass of element.cssClasses)
                 setClass(vnode, cssClass, true);

--- a/packages/sprotty/src/base/views/dom-helper.ts
+++ b/packages/sprotty/src/base/views/dom-helper.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from "inversify";
 import { ViewerOptions } from "./viewer-options";
 import { TYPES } from "../types";
-import { SModelElement } from "../model/smodel";
+import { SModelElementImpl } from "../model/smodel";
 
 @injectable()
 export class DOMHelper {
@@ -30,7 +30,7 @@ export class DOMHelper {
         return prefix;
     }
 
-    createUniqueDOMElementId(element: SModelElement): string {
+    createUniqueDOMElementId(element: SModelElementImpl): string {
         return this.getPrefix() + element.id;
     }
 

--- a/packages/sprotty/src/base/views/id-postprocessor.ts
+++ b/packages/sprotty/src/base/views/id-postprocessor.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from "inversify";
 import { VNode } from "snabbdom";
 import { TYPES } from "../types";
 import { ILogger } from "../../utils/logging";
-import { SModelElement } from "../model/smodel";
+import { SModelElementImpl } from "../model/smodel";
 import { IVNodePostprocessor } from "./vnode-postprocessor";
 import { DOMHelper } from "./dom-helper";
 import { getAttrs } from "./vnode-utils";
@@ -29,7 +29,7 @@ export class IdPostprocessor implements IVNodePostprocessor {
     @inject(TYPES.ILogger) protected logger: ILogger;
     @inject(TYPES.DOMHelper) protected domHelper: DOMHelper;
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         const attrs = getAttrs(vnode);
         if (attrs.id !== undefined)
             this.logger.warn(vnode, 'Overriding id of vnode (' + attrs.id + '). Make sure not to set it manually in view.');

--- a/packages/sprotty/src/base/views/key-tool.ts
+++ b/packages/sprotty/src/base/views/key-tool.ts
@@ -19,7 +19,7 @@ import { VNode } from "snabbdom";
 import { Action } from "sprotty-protocol/lib/actions";
 import { TYPES } from "../types";
 import { IActionDispatcher } from "../actions/action-dispatcher";
-import { SModelElement, SModelRoot } from "../model/smodel";
+import { SModelElementImpl, SModelRootImpl } from "../model/smodel";
 import { IVNodePostprocessor } from "./vnode-postprocessor";
 import { on } from "./vnode-utils";
 
@@ -40,7 +40,7 @@ export class KeyTool implements IVNodePostprocessor {
             this.keyListeners.splice(index, 1);
     }
 
-    protected handleEvent<K extends keyof KeyListener>(methodName: K, model: SModelRoot, event: KeyboardEvent) {
+    protected handleEvent<K extends keyof KeyListener>(methodName: K, model: SModelRootImpl, event: KeyboardEvent) {
         const actions = this.keyListeners
             .map(listener => listener[methodName].apply(listener, [model, event]))
             .reduce((a, b) => a.concat(b));
@@ -50,18 +50,18 @@ export class KeyTool implements IVNodePostprocessor {
         }
     }
 
-    keyDown(element: SModelRoot, event: KeyboardEvent): void {
+    keyDown(element: SModelRootImpl, event: KeyboardEvent): void {
         this.handleEvent('keyDown', element, event);
     }
 
-    keyUp(element: SModelRoot, event: KeyboardEvent): void {
+    keyUp(element: SModelRootImpl, event: KeyboardEvent): void {
         this.handleEvent('keyUp', element, event);
     }
 
     focus() {}
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
-        if (element instanceof SModelRoot) {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
+        if (element instanceof SModelRootImpl) {
             on(vnode, 'focus', this.focus.bind(this, element));
             on(vnode, 'keydown', this.keyDown.bind(this, element));
             on(vnode, 'keyup', this.keyUp.bind(this, element));
@@ -75,11 +75,11 @@ export class KeyTool implements IVNodePostprocessor {
 
 @injectable()
 export class KeyListener {
-    keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         return [];
     }
 
-    keyUp(element: SModelElement, event: KeyboardEvent): Action[] {
+    keyUp(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         return [];
     }
 }

--- a/packages/sprotty/src/base/views/mouse-tool.ts
+++ b/packages/sprotty/src/base/views/mouse-tool.ts
@@ -19,7 +19,7 @@ import { VNode } from "snabbdom";
 import { Action, isAction } from "sprotty-protocol/lib/actions";
 import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { IActionDispatcher } from "../actions/action-dispatcher";
-import { SModelElement, SModelRoot } from "../model/smodel";
+import { SModelElementImpl, SModelRootImpl } from "../model/smodel";
 import { TYPES } from "../types";
 import { DOMHelper } from "./dom-helper";
 import { IVNodePostprocessor } from "./vnode-postprocessor";
@@ -43,7 +43,7 @@ export class MouseTool implements IVNodePostprocessor {
             this.mouseListeners.splice(index, 1);
     }
 
-    protected getTargetElement(model: SModelRoot, event: MouseEvent): SModelElement | undefined {
+    protected getTargetElement(model: SModelRootImpl, event: MouseEvent): SModelElementImpl | undefined {
         let target = event.target as Element;
         const index = model.index;
         while (target) {
@@ -57,7 +57,7 @@ export class MouseTool implements IVNodePostprocessor {
         return undefined;
     }
 
-    protected handleEvent(methodName: MouseEventKind, model: SModelRoot, event: MouseEvent) {
+    protected handleEvent(methodName: MouseEventKind, model: SModelRootImpl, event: MouseEvent) {
         this.focusOnMouseEvent(methodName, model);
         const element = this.getTargetElement(model, event);
         if (!element)
@@ -79,7 +79,7 @@ export class MouseTool implements IVNodePostprocessor {
         }
     }
 
-    protected focusOnMouseEvent<K extends keyof MouseListener>(methodName: K, model: SModelRoot) {
+    protected focusOnMouseEvent<K extends keyof MouseListener>(methodName: K, model: SModelRootImpl) {
         if (document && methodName === 'mouseDown') {
             const domElement = document.getElementById(this.domHelper.createUniqueDOMElementId(model));
             if (domElement !== null && typeof domElement.focus === 'function')
@@ -87,49 +87,49 @@ export class MouseTool implements IVNodePostprocessor {
         }
     }
 
-    mouseOver(model: SModelRoot, event: MouseEvent) {
+    mouseOver(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('mouseOver', model, event);
     }
 
-    mouseOut(model: SModelRoot, event: MouseEvent) {
+    mouseOut(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('mouseOut', model, event);
     }
 
-    mouseEnter(model: SModelRoot, event: MouseEvent) {
+    mouseEnter(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('mouseEnter', model, event);
     }
 
-    mouseLeave(model: SModelRoot, event: MouseEvent) {
+    mouseLeave(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('mouseLeave', model, event);
     }
 
-    mouseDown(model: SModelRoot, event: MouseEvent) {
+    mouseDown(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('mouseDown', model, event);
     }
 
-    mouseMove(model: SModelRoot, event: MouseEvent) {
+    mouseMove(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('mouseMove', model, event);
     }
 
-    mouseUp(model: SModelRoot, event: MouseEvent) {
+    mouseUp(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('mouseUp', model, event);
     }
 
-    wheel(model: SModelRoot, event: WheelEvent) {
+    wheel(model: SModelRootImpl, event: WheelEvent) {
         this.handleEvent('wheel', model, event);
     }
 
-    contextMenu(model: SModelRoot, event: MouseEvent) {
+    contextMenu(model: SModelRootImpl, event: MouseEvent) {
         event.preventDefault();
         this.handleEvent('contextMenu', model, event);
     }
 
-    doubleClick(model: SModelRoot, event: MouseEvent) {
+    doubleClick(model: SModelRootImpl, event: MouseEvent) {
         this.handleEvent('doubleClick', model, event);
     }
 
-    decorate(vnode: VNode, element: SModelElement) {
-        if (element instanceof SModelRoot) {
+    decorate(vnode: VNode, element: SModelElementImpl) {
+        if (element instanceof SModelRootImpl) {
             on(vnode, 'mouseover', this.mouseOver.bind(this, element));
             on(vnode, 'mouseout', this.mouseOut.bind(this, element));
             on(vnode, 'mouseenter', this.mouseEnter.bind(this, element));
@@ -167,55 +167,55 @@ export type MouseEventKind =
 @injectable()
 export class MouseListener {
 
-    mouseOver(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    mouseOver(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    mouseOut(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    mouseOut(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    mouseEnter(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    mouseEnter(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    mouseLeave(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    mouseLeave(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    mouseDown(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    mouseMove(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    mouseMove(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    mouseUp(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    mouseUp(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    wheel(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
+    wheel(target: SModelElementImpl, event: WheelEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    doubleClick(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    contextMenu(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    contextMenu(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    dragOver(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    dragOver(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    drop(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    drop(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         return vnode;
     }
 }
@@ -225,7 +225,7 @@ export class MousePositionTracker extends MouseListener {
 
     protected lastPosition: Point | undefined;
 
-    override mouseMove(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override mouseMove(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         this.lastPosition = target.root.parentToLocal({ x: event.offsetX, y: event.offsetY });
         return [];
     }

--- a/packages/sprotty/src/base/views/thunk-view.ts
+++ b/packages/sprotty/src/base/views/thunk-view.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { h, VNode, VNodeData } from "snabbdom";
-import { SModelElement } from "../model/smodel";
+import { SModelElementImpl } from "../model/smodel";
 import { RenderingContext, IView } from "./view";
 import { injectable } from "inversify";
 
@@ -30,19 +30,19 @@ export abstract class ThunkView implements IView {
      * Returns the array of values that are watched for changes.
      * If they haven't change since the last rendering, the VNode is neither recalculated nor patched.
      */
-    abstract watchedArgs(model: SModelElement): any[];
+    abstract watchedArgs(model: SModelElementImpl): any[];
 
     /**
      * Returns the selector of the VNode root, i.e. it's element type.
      */
-    abstract selector(model: SModelElement): string;
+    abstract selector(model: SModelElementImpl): string;
 
     /**
      * Calculate the VNode from the input data. Only called if the watched properties change.
      */
-    abstract doRender(model: SModelElement, context: RenderingContext): VNode;
+    abstract doRender(model: SModelElementImpl, context: RenderingContext): VNode;
 
-    render(model: SModelElement, context: RenderingContext): VNode {
+    render(model: SModelElementImpl, context: RenderingContext): VNode {
         return h(this.selector(model), {
             key: model.id,
             hook: {
@@ -54,7 +54,7 @@ export abstract class ThunkView implements IView {
         });
     }
 
-    protected renderAndDecorate(model: SModelElement, context: RenderingContext): VNode {
+    protected renderAndDecorate(model: SModelElementImpl, context: RenderingContext): VNode {
         const vnode = this.doRender(model, context);
         context.decorate(vnode, model);
         return vnode;

--- a/packages/sprotty/src/base/views/view.tsx
+++ b/packages/sprotty/src/base/views/view.tsx
@@ -22,7 +22,7 @@ import { VNode } from 'snabbdom';
 import { TYPES } from '../types';
 import { InstanceRegistry } from '../../utils/registry';
 import { isInjectable } from '../../utils/inversify';
-import { SModelElement, SModelRoot, SParentElement } from '../model/smodel';
+import { SModelElementImpl, SModelRootImpl, SParentElementImpl } from '../model/smodel';
 import { EMPTY_ROOT, CustomFeatures } from '../model/smodel-factory';
 import { registerModelElement } from '../model/smodel-utils';
 import { Point } from 'sprotty-protocol';
@@ -54,7 +54,7 @@ export function findArgValue<T>(arg: IViewArgs | undefined, key: string): T | un
  * Base interface for the components that turn GModelElements into virtual DOM elements.
  */
 export interface IView<A extends IViewArgs = {}> {
-    render(model: Readonly<SModelElement>, context: RenderingContext, args?: A): VNode | undefined
+    render(model: Readonly<SModelElementImpl>, context: RenderingContext, args?: A): VNode | undefined
 }
 
 /**
@@ -72,11 +72,11 @@ export interface RenderingContext {
     readonly targetKind: RenderingTargetKind;
     readonly parentArgs?: IViewArgs;
 
-    decorate(vnode: VNode, element: Readonly<SModelElement>): VNode
+    decorate(vnode: VNode, element: Readonly<SModelElementImpl>): VNode
 
-    renderElement(element: Readonly<SModelElement>): VNode | undefined
+    renderElement(element: Readonly<SModelElementImpl>): VNode | undefined
 
-    renderChildren(element: Readonly<SParentElement>, args?: IViewArgs): VNode[]
+    renderChildren(element: Readonly<SParentElementImpl>, args?: IViewArgs): VNode[]
 }
 
 /**
@@ -115,7 +115,7 @@ export class ViewRegistry extends InstanceRegistry<IView> {
  * Combines `registerModelElement` and `configureView`.
  */
 export function configureModelElement(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
-        type: string, modelConstr: new () => SModelElement, viewConstr: interfaces.ServiceIdentifier<IView>,
+        type: string, modelConstr: new () => SModelElementImpl, viewConstr: interfaces.ServiceIdentifier<IView>,
         features?: CustomFeatures): void {
     registerModelElement(context, type, modelConstr, features);
     configureView(context, type, viewConstr);
@@ -145,7 +145,7 @@ export function configureView(context: { bind: interfaces.Bind, isBound: interfa
  */
 @injectable()
 export class EmptyView implements IView {
-    render(model: SModelRoot, context: RenderingContext): VNode {
+    render(model: SModelRootImpl, context: RenderingContext): VNode {
         return <svg class-sprotty-empty={true} />;
     }
 }
@@ -155,7 +155,7 @@ export class EmptyView implements IView {
  */
 @injectable()
 export class MissingView implements IView {
-    render(model: Readonly<SModelElement>, context: RenderingContext): VNode {
+    render(model: Readonly<SModelElementImpl>, context: RenderingContext): VNode {
         const position: Point = (model as any).position || Point.ORIGIN;
         return <text class-sprotty-missing={true} x={position.x} y={position.y}>?{model.id}?</text>;
     }

--- a/packages/sprotty/src/base/views/viewer-cache.ts
+++ b/packages/sprotty/src/base/views/viewer-cache.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from "inversify";
 import { Action } from "sprotty-protocol/lib/actions";
-import { SModelRoot } from "../model/smodel";
+import { SModelRootImpl } from "../model/smodel";
 import { TYPES } from "../types";
 import { AnimationFrameSyncer } from "../animations/animation-frame-syncer";
 import { IViewer } from "./viewer";
@@ -33,9 +33,9 @@ export class ViewerCache implements IViewer {
     @inject(TYPES.IViewer) protected delegate: IViewer;
     @inject(TYPES.AnimationFrameSyncer) protected syncer: AnimationFrameSyncer;
 
-    protected cachedModel?: SModelRoot;
+    protected cachedModel?: SModelRootImpl;
 
-    update(model: SModelRoot, cause?: Action): void {
+    update(model: SModelRootImpl, cause?: Action): void {
         if (cause !== undefined) {
             // Forward the update immediately in order to pass the cause action
             this.delegate.update(model, cause);

--- a/packages/sprotty/src/base/views/viewer.tsx
+++ b/packages/sprotty/src/base/views/viewer.tsx
@@ -23,7 +23,7 @@ import { getWindowScroll } from '../../utils/browser';
 import { ILogger } from '../../utils/logging';
 import { IActionDispatcher } from '../actions/action-dispatcher';
 import { InitializeCanvasBoundsAction } from '../features/initialize-canvas';
-import { SModelElement, SModelRoot, SParentElement } from '../model/smodel';
+import { SModelElementImpl, SModelRootImpl, SParentElementImpl } from '../model/smodel';
 import { EMPTY_ROOT } from '../model/smodel-factory';
 import { TYPES } from '../types';
 import { isThunk } from './thunk-view';
@@ -34,7 +34,7 @@ import { copyClassesFromElement, copyClassesFromVNode, setAttr, setClass } from 
 
 
 export interface IViewer {
-    update(model: SModelRoot, cause?: Action): void
+    update(model: SModelRootImpl, cause?: Action): void
 }
 
 export interface IViewerProvider {
@@ -51,7 +51,7 @@ export class ModelRenderer implements RenderingContext {
         protected args: IViewArgs = {}) {
     }
 
-    decorate(vnode: VNode, element: Readonly<SModelElement>): VNode {
+    decorate(vnode: VNode, element: Readonly<SModelElementImpl>): VNode {
         if (isThunk(vnode)) {
             return vnode;
         }
@@ -60,7 +60,7 @@ export class ModelRenderer implements RenderingContext {
             vnode);
     }
 
-    renderElement(element: Readonly<SModelElement>): VNode | undefined {
+    renderElement(element: Readonly<SModelElementImpl>): VNode | undefined {
         const view = this.viewRegistry.get(element.type);
         const vnode = view.render(element, this, this.args);
         if (vnode) {
@@ -70,7 +70,7 @@ export class ModelRenderer implements RenderingContext {
         }
     }
 
-    renderChildren(element: Readonly<SParentElement>, args?: IViewArgs): VNode[] {
+    renderChildren(element: Readonly<SParentElementImpl>, args?: IViewArgs): VNode[] {
         const context = args ?
             new ModelRenderer(
                 this.viewRegistry,
@@ -140,7 +140,7 @@ export class ModelViewer implements IViewer {
 
     protected lastVDOM: VNode;
 
-    update(model: Readonly<SModelRoot>, cause?: Action): void {
+    update(model: Readonly<SModelRootImpl>, cause?: Action): void {
         this.logger.log(this, 'rendering', model);
         const newVDOM = <div id={this.options.baseDiv}>
             {this.renderer.renderElement(model)}
@@ -234,7 +234,7 @@ export class HiddenModelViewer implements IViewer {
 
     protected lastHiddenVDOM: VNode;
 
-    update(hiddenModel: Readonly<SModelRoot>, cause?: Action): void {
+    update(hiddenModel: Readonly<SModelRootImpl>, cause?: Action): void {
         this.logger.log(this, 'rendering hidden');
 
         let newVDOM: VNode;
@@ -288,7 +288,7 @@ export class PopupModelViewer implements IViewer {
 
     protected lastPopupVDOM: VNode;
 
-    update(model: Readonly<SModelRoot>, cause?: Action): void {
+    update(model: Readonly<SModelRootImpl>, cause?: Action): void {
         this.logger.log(this, 'rendering popup', model);
 
         const popupClosed = model.type === EMPTY_ROOT.type;

--- a/packages/sprotty/src/base/views/vnode-postprocessor.ts
+++ b/packages/sprotty/src/base/views/vnode-postprocessor.ts
@@ -17,7 +17,7 @@
 import { injectable } from "inversify";
 import { VNode } from "snabbdom";
 import { Action } from "sprotty-protocol/lib/actions";
-import { SModelElement } from "../model/smodel";
+import { SModelElementImpl } from "../model/smodel";
 import { setAttr } from "./vnode-utils";
 
 /**
@@ -25,14 +25,14 @@ import { setAttr } from "./vnode-utils";
  * Used to register listeners and add animations.
  */
 export interface IVNodePostprocessor {
-    decorate(vnode: VNode, element: SModelElement): VNode
+    decorate(vnode: VNode, element: SModelElementImpl): VNode
     postUpdate(cause?: Action): void
 }
 
 @injectable()
 export class FocusFixPostprocessor implements IVNodePostprocessor {
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         if (vnode.sel && vnode.sel.startsWith('svg'))
             // allows to set focus in Firefox
             setAttr(vnode, 'tabindex', 0);

--- a/packages/sprotty/src/features/bounds/abstract-layout.ts
+++ b/packages/sprotty/src/features/bounds/abstract-layout.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
-import { SParentElement, SModelElement, SChildElement } from "../../base/model/smodel";
+import { SParentElementImpl, SModelElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { isLayoutContainer, isLayoutableChild, LayoutContainer, isBoundsAware } from "./model";
 import { ILayout, StatefulLayouter } from './layout';
 import { AbstractLayoutOptions, HAlignment, VAlignment } from './layout-options';
@@ -25,7 +25,7 @@ import { injectable } from "inversify";
 @injectable()
 export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements ILayout {
 
-    layout(container: SParentElement & LayoutContainer,
+    layout(container: SParentElementImpl & LayoutContainer,
            layouter: StatefulLayouter) {
         const boundsData = layouter.getBoundsData(container);
         const options = this.getLayoutOptions(container);
@@ -44,13 +44,13 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
             boundsData.boundsChanged = true;
         }
     }
-    protected abstract layoutChild(child: SChildElement,
+    protected abstract layoutChild(child: SChildElementImpl,
                                 boundsData: BoundsData, bounds: Bounds,
                                 childOptions: T, containerOptions: T,
                                 currentOffset: Point,
                                 maxWidth: number, maxHeight: number): Point;
 
-    protected getFinalContainerBounds(container: SParentElement & LayoutContainer,
+    protected getFinalContainerBounds(container: SParentElementImpl & LayoutContainer,
                                     lastOffset: Point,
                                     options: T,
                                     maxWidth: number,
@@ -64,7 +64,7 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
     }
 
     protected getFixedContainerBounds(
-            container: SModelElement,
+            container: SModelElementImpl,
             layoutOptions: T,
             layouter: StatefulLayouter): Bounds {
         let currentContainer = container;
@@ -76,7 +76,7 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
                 if (Dimension.isValid(bounds))
                     return bounds;
             }
-            if (currentContainer instanceof SChildElement) {
+            if (currentContainer instanceof SChildElementImpl) {
                 currentContainer = currentContainer.parent;
             } else {
                 layouter.log.error(currentContainer, 'Cannot detect fixed bounds');
@@ -85,11 +85,11 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
         }
     }
 
-    protected abstract getChildrenSize(container: SParentElement & LayoutContainer,
+    protected abstract getChildrenSize(container: SParentElementImpl & LayoutContainer,
                                containerOptions: T,
                                layouter: StatefulLayouter): Dimension;
 
-    protected layoutChildren(container: SParentElement & LayoutContainer,
+    protected layoutChildren(container: SParentElementImpl & LayoutContainer,
                             layouter: StatefulLayouter,
                             containerOptions: T,
                             maxWidth: number,
@@ -136,7 +136,7 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
         }
     }
 
-    protected getChildLayoutOptions(child: SChildElement, containerOptions: T): T {
+    protected getChildLayoutOptions(child: SChildElementImpl, containerOptions: T): T {
         const layoutOptions = (child as any).layoutOptions;
         if (layoutOptions === undefined)
             return containerOptions;
@@ -144,14 +144,14 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
             return this.spread(containerOptions, layoutOptions);
     }
 
-    protected getLayoutOptions(element: SModelElement): T {
+    protected getLayoutOptions(element: SModelElementImpl): T {
         let current = element;
         const allOptions: T[] = [];
         while (current !== undefined) {
             const layoutOptions = (current as any).layoutOptions;
             if (layoutOptions !== undefined)
                 allOptions.push(layoutOptions);
-            if (current instanceof SChildElement)
+            if (current instanceof SChildElementImpl)
                 current = current.parent;
             else
                 break;

--- a/packages/sprotty/src/features/bounds/bounds-manipulation.ts
+++ b/packages/sprotty/src/features/bounds/bounds-manipulation.ts
@@ -21,7 +21,7 @@ import * as protocol from "sprotty-protocol/lib/actions";
 import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
 import { CommandExecutionContext, CommandResult, CommandReturn, HiddenCommand, SystemCommand } from "../../base/commands/command";
-import { SModelElement } from "../../base/model/smodel";
+import { SModelElementImpl } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
 import { Alignable, BoundsAware, isBoundsAware } from './model';
 
@@ -114,14 +114,14 @@ export class LayoutAction implements Action, protocol.LayoutAction {
 }
 
 export interface ResolvedElementAndBounds {
-    element: SModelElement & BoundsAware
+    element: SModelElementImpl & BoundsAware
     oldBounds: Bounds
     newPosition?: Point
     newSize: Dimension
 }
 
 export interface ResolvedElementAndAlignment {
-    element: SModelElement & Alignable
+    element: SModelElementImpl & Alignable
     oldAlignment: Point
     newAlignment: Point
 }

--- a/packages/sprotty/src/features/bounds/hbox-layout.ts
+++ b/packages/sprotty/src/features/bounds/hbox-layout.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SParentElement, SChildElement } from "../../base/model/smodel";
+import { SParentElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, VAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
@@ -36,7 +36,7 @@ export class HBoxLayouter extends AbstractLayout<HBoxLayoutOptions> {
 
     static KIND = 'hbox';
 
-    protected getChildrenSize(container: SParentElement & LayoutContainer,
+    protected getChildrenSize(container: SParentElementImpl & LayoutContainer,
                                containerOptions: HBoxLayoutOptions,
                                layouter: StatefulLayouter) {
         let maxWidth = 0;
@@ -63,7 +63,7 @@ export class HBoxLayouter extends AbstractLayout<HBoxLayoutOptions> {
         };
     }
 
-    protected layoutChild(child: SChildElement,
+    protected layoutChild(child: SChildElementImpl,
                         boundsData: BoundsData,
                         bounds: Bounds,
                         childOptions: HBoxLayoutOptions,

--- a/packages/sprotty/src/features/bounds/hidden-bounds-updater.ts
+++ b/packages/sprotty/src/features/bounds/hidden-bounds-updater.ts
@@ -20,7 +20,7 @@ import { Action, ComputedBoundsAction, ElementAndAlignment, ElementAndBounds, Re
 import { almostEquals, Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
 import { ILogger } from "../../utils/logging";
 import { IActionDispatcher } from "../../base/actions/action-dispatcher";
-import { SChildElement, SModelElement, SModelRoot } from "../../base/model/smodel";
+import { SChildElementImpl, SModelElementImpl, SModelRootImpl } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
 import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
 import { Layouter } from "./layout";
@@ -52,11 +52,11 @@ export class HiddenBoundsUpdater implements IVNodePostprocessor {
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(TYPES.Layouter) protected layouter: Layouter;
 
-    private readonly element2boundsData: Map<SModelElement, BoundsData> = new Map;
+    private readonly element2boundsData: Map<SModelElementImpl, BoundsData> = new Map;
 
-    root: SModelRoot | undefined;
+    root: SModelRootImpl | undefined;
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         if (isSizeable(element) || isLayoutContainer(element)) {
             this.element2boundsData.set(element, {
                 vnode: vnode,
@@ -65,7 +65,7 @@ export class HiddenBoundsUpdater implements IVNodePostprocessor {
                 alignmentChanged: false
             });
         }
-        if (element instanceof SModelRoot)
+        if (element instanceof SModelRootImpl)
             this.root = element;
         return vnode;
     }
@@ -90,7 +90,7 @@ export class HiddenBoundsUpdater implements IVNodePostprocessor {
                         }
                     };
                     // don't copy position if the element is layouted by the server
-                    if (element instanceof SChildElement && isLayoutContainer(element.parent)) {
+                    if (element instanceof SChildElementImpl && isLayoutContainer(element.parent)) {
                         resize.newPosition = {
                             x: boundsData.bounds.x,
                             y: boundsData.bounds.y,

--- a/packages/sprotty/src/features/bounds/layout.ts
+++ b/packages/sprotty/src/features/bounds/layout.ts
@@ -19,7 +19,7 @@ import { Bounds } from "sprotty-protocol/lib/utils/geometry";
 import { TYPES } from "../../base/types";
 import { ILogger } from '../../utils/logging';
 import { InstanceRegistry } from "../../utils/registry";
-import { SParentElement, SModelElement } from "../../base/model/smodel";
+import { SParentElementImpl, SModelElementImpl } from "../../base/model/smodel";
 import { isLayoutContainer, LayoutContainer } from "./model";
 import { BoundsData } from "./hidden-bounds-updater";
 import { isInjectable } from "../../utils/inversify";
@@ -52,16 +52,16 @@ export class Layouter {
     @inject(TYPES.LayoutRegistry) protected layoutRegistry: LayoutRegistry;
     @inject(TYPES.ILogger) protected logger: ILogger;
 
-    layout(element2boundsData: Map<SModelElement​​ , BoundsData>) {
+    layout(element2boundsData: Map<SModelElementImpl​​ , BoundsData>) {
         new StatefulLayouter(element2boundsData, this.layoutRegistry, this.logger).layout();
     }
 }
 
 export class StatefulLayouter {
 
-    private toBeLayouted: (SParentElement & LayoutContainer)[];
+    private toBeLayouted: (SParentElementImpl & LayoutContainer)[];
 
-    constructor(private readonly element2boundsData: Map<SModelElement​​ , BoundsData>,
+    constructor(private readonly element2boundsData: Map<SModelElementImpl​​ , BoundsData>,
                 private readonly layoutRegistry: LayoutRegistry,
                 public readonly log: ILogger) {
         this.toBeLayouted = [];
@@ -72,7 +72,7 @@ export class StatefulLayouter {
             });
     }
 
-    getBoundsData(element: SModelElement): BoundsData {
+    getBoundsData(element: SModelElementImpl): BoundsData {
         let boundsData = this.element2boundsData.get(element);
         let bounds = (element as any).bounds;
         if (isLayoutContainer(element) && this.toBeLayouted.indexOf(element) >= 0) {
@@ -96,7 +96,7 @@ export class StatefulLayouter {
         }
     }
 
-    protected doLayout(element: SParentElement & LayoutContainer): Bounds {
+    protected doLayout(element: SParentElementImpl & LayoutContainer): Bounds {
         const index = this.toBeLayouted.indexOf(element);
         if (index >= 0)
             this.toBeLayouted.splice(index, 1);
@@ -114,7 +114,7 @@ export class StatefulLayouter {
 }
 
 export interface ILayout {
-    layout(container: SParentElement & LayoutContainer,
+    layout(container: SParentElementImpl & LayoutContainer,
            layouter: StatefulLayouter): void
 }
 

--- a/packages/sprotty/src/features/bounds/model.ts
+++ b/packages/sprotty/src/features/bounds/model.ts
@@ -16,7 +16,7 @@
 
 import { Bounds, Dimension, isBounds, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SModelElement as SModelElementSchema } from 'sprotty-protocol/lib/model';
-import { SChildElement, SModelElement, SModelRoot, SParentElement } from '../../base/model/smodel';
+import { SChildElementImpl, SModelElementImpl, SModelRootImpl, SParentElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { DOMHelper } from '../../base/views/dom-helper';
@@ -59,42 +59,42 @@ export interface Alignable extends SModelExtension {
     alignment: Point
 }
 
-export function isBoundsAware(element: SModelElement): element is SModelElement & BoundsAware {
+export function isBoundsAware(element: SModelElementImpl): element is SModelElementImpl & BoundsAware {
     return 'bounds' in element;
 }
 
-export function isLayoutContainer(element: SModelElement): element is SParentElement & LayoutContainer {
+export function isLayoutContainer(element: SModelElementImpl): element is SParentElementImpl & LayoutContainer {
     return isBoundsAware(element)
         && element.hasFeature(layoutContainerFeature)
         && 'layout' in element;
 }
 
-export function isLayoutableChild(element: SModelElement): element is SChildElement & LayoutableChild {
+export function isLayoutableChild(element: SModelElementImpl): element is SChildElementImpl & LayoutableChild {
     return isBoundsAware(element)
         && element.hasFeature(layoutableChildFeature);
 }
 
-export function isSizeable(element: SModelElement): element is SModelElement & BoundsAware {
+export function isSizeable(element: SModelElementImpl): element is SModelElementImpl & BoundsAware {
     return element.hasFeature(boundsFeature) && isBoundsAware(element);
 }
 
-export function isAlignable(element: SModelElement): element is SModelElement & Alignable {
+export function isAlignable(element: SModelElementImpl): element is SModelElementImpl & Alignable {
     return element.hasFeature(alignFeature)
         && 'alignment' in element;
 }
 
-export function getAbsoluteBounds(element: SModelElement): Bounds {
+export function getAbsoluteBounds(element: SModelElementImpl): Bounds {
     const boundsAware = findParentByFeature(element, isBoundsAware);
     if (boundsAware !== undefined) {
         let bounds = boundsAware.bounds;
-        let current: SModelElement = boundsAware;
-        while (current instanceof SChildElement) {
+        let current: SModelElementImpl = boundsAware;
+        while (current instanceof SChildElementImpl) {
             const parent = current.parent;
             bounds = parent.localToParent(bounds);
             current = parent;
         }
         return bounds;
-    } else if (element instanceof SModelRoot) {
+    } else if (element instanceof SModelRootImpl) {
         const canvasBounds = element.canvasBounds;
         return { x: 0, y: 0, width: canvasBounds.width, height: canvasBounds.height };
     } else {
@@ -111,7 +111,7 @@ export function getAbsoluteBounds(element: SModelElement): Bounds {
  * @param domHelper The dom helper to obtain the SVG element's id.
  * @param viewerOptions The viewer options to obtain sprotty's container div id.
  */
-export function getAbsoluteClientBounds(element: SModelElement, domHelper: DOMHelper, viewerOptions: ViewerOptions): Bounds {
+export function getAbsoluteClientBounds(element: SModelElementImpl, domHelper: DOMHelper, viewerOptions: ViewerOptions): Bounds {
     let x = 0;
     let y = 0;
     let width = 0;
@@ -140,17 +140,17 @@ export function getAbsoluteClientBounds(element: SModelElement, domHelper: DOMHe
     return { x, y, width, height };
 }
 
-export function findChildrenAtPosition(parent: SParentElement, point: Point): SModelElement[] {
-    const matches: SModelElement[] = [];
+export function findChildrenAtPosition(parent: SParentElementImpl, point: Point): SModelElementImpl[] {
+    const matches: SModelElementImpl[] = [];
     doFindChildrenAtPosition(parent, point, matches);
     return matches;
 }
 
-function doFindChildrenAtPosition(parent: SParentElement, point: Point, matches: SModelElement[]) {
+function doFindChildrenAtPosition(parent: SParentElementImpl, point: Point, matches: SModelElementImpl[]) {
     parent.children.forEach(child => {
         if (isBoundsAware(child) && Bounds.includes(child.bounds, point))
             matches.push(child);
-        if (child instanceof SParentElement) {
+        if (child instanceof SParentElementImpl) {
             const newPoint = child.parentToLocal(point);
             doFindChildrenAtPosition(child, newPoint, matches);
         }
@@ -171,7 +171,8 @@ export interface SShapeElementSchema extends SModelElementSchema {
 /**
  * Abstract class for elements with a position and a size.
  */
-export abstract class SShapeElement extends SChildElement implements BoundsAware, Locateable, LayoutableChild {
+export abstract class SShapeElementImpl extends SChildElementImpl implements BoundsAware, Locateable, LayoutableChild {
+
     position: Point = Point.ORIGIN;
     size: Dimension = Dimension.EMPTY;
     layoutOptions?: ModelLayoutOptions;
@@ -223,4 +224,8 @@ export abstract class SShapeElement extends SChildElement implements BoundsAware
         }
         return result;
     }
+
 }
+
+/** @deprecated Use `SShapeElementImpl` instead. */
+export const SShapeElement = SShapeElementImpl;

--- a/packages/sprotty/src/features/bounds/resize.ts
+++ b/packages/sprotty/src/features/bounds/resize.ts
@@ -16,18 +16,18 @@
 
 import { Dimension } from "sprotty-protocol/lib/utils/geometry";
 import { Animation } from "../../base/animations/animation";
-import { SModelRoot, SModelElement } from "../../base/model/smodel";
+import { SModelRootImpl, SModelElementImpl } from "../../base/model/smodel";
 import { CommandExecutionContext } from "../../base/commands/command";
 import { BoundsAware } from './model';
 
 export interface ResolvedElementResize {
-    element: SModelElement & BoundsAware
+    element: SModelElementImpl & BoundsAware
     fromDimension: Dimension
     toDimension: Dimension
 }
 
 export class ResizeAnimation extends Animation {
-    constructor(protected model: SModelRoot,
+    constructor(protected model: SModelRootImpl,
         public elementResizes: Map<string, ResolvedElementResize>,
         context: CommandExecutionContext,
         protected reverse: boolean = false) {

--- a/packages/sprotty/src/features/bounds/stack-layout.ts
+++ b/packages/sprotty/src/features/bounds/stack-layout.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SParentElement, SChildElement } from "../../base/model/smodel";
+import { SParentElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, HAlignment, VAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
@@ -34,7 +34,7 @@ export class StackLayouter extends AbstractLayout<StackLayoutOptions> {
 
     static KIND = 'stack';
 
-    protected getChildrenSize(container: SParentElement & LayoutContainer,
+    protected getChildrenSize(container: SParentElementImpl & LayoutContainer,
                             options: StackLayoutOptions,
                             layouter: StatefulLayouter) {
         let maxWidth = -1;
@@ -56,7 +56,7 @@ export class StackLayouter extends AbstractLayout<StackLayoutOptions> {
         };
     }
 
-    protected layoutChild(child: SChildElement,
+    protected layoutChild(child: SChildElementImpl,
                         boundsData: BoundsData,
                         bounds: Bounds,
                         childOptions: StackLayoutOptions,

--- a/packages/sprotty/src/features/bounds/vbox-layout.ts
+++ b/packages/sprotty/src/features/bounds/vbox-layout.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SParentElement, SChildElement } from "../../base/model/smodel";
+import { SParentElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, HAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
@@ -36,7 +36,7 @@ export class VBoxLayouter extends AbstractLayout<VBoxLayoutOptions> {
 
     static KIND = 'vbox';
 
-    protected getChildrenSize(container: SParentElement & LayoutContainer,
+    protected getChildrenSize(container: SParentElementImpl & LayoutContainer,
                                containerOptions: VBoxLayoutOptions,
                                layouter: StatefulLayouter) {
         let maxWidth = -1;
@@ -63,7 +63,7 @@ export class VBoxLayouter extends AbstractLayout<VBoxLayoutOptions> {
         };
     }
 
-    protected layoutChild(child: SChildElement,
+    protected layoutChild(child: SChildElementImpl,
                         boundsData: BoundsData,
                         bounds: Bounds,
                         childOptions: VBoxLayoutOptions,

--- a/packages/sprotty/src/features/bounds/views.ts
+++ b/packages/sprotty/src/features/bounds/views.ts
@@ -19,7 +19,7 @@ import { VNode } from 'snabbdom';
 import { Dimension } from 'sprotty-protocol/lib/utils/geometry';
 import { IViewArgs, IView, RenderingContext } from '../../base/views/view';
 import { getAbsoluteBounds, BoundsAware } from './model';
-import { SChildElement } from '../../base/model/smodel';
+import { SChildElementImpl } from '../../base/model/smodel';
 
 @injectable()
 export abstract class ShapeView implements IView {
@@ -29,7 +29,7 @@ export abstract class ShapeView implements IView {
      * in your `render` implementation to skip rendering in case the element is not visible.
      * This can greatly enhance performance for large models.
      */
-    isVisible(model: Readonly<SChildElement & BoundsAware>, context: RenderingContext): boolean {
+    isVisible(model: Readonly<SChildElementImpl & BoundsAware>, context: RenderingContext): boolean {
         if (context.targetKind === 'hidden') {
             // Don't hide any element for hidden rendering
             return true;
@@ -46,6 +46,6 @@ export abstract class ShapeView implements IView {
             && ab.y + ab.height >= 0;
     }
 
-    abstract render(model: Readonly<SChildElement>, context: RenderingContext, args?: IViewArgs): VNode | undefined;
+    abstract render(model: Readonly<SChildElementImpl>, context: RenderingContext, args?: IViewArgs): VNode | undefined;
 
 }

--- a/packages/sprotty/src/features/button/button-handler.ts
+++ b/packages/sprotty/src/features/button/button-handler.ts
@@ -18,11 +18,11 @@ import { injectable, interfaces, multiInject, optional } from 'inversify';
 import { Action } from 'sprotty-protocol/lib/actions';
 import { InstanceRegistry } from '../../utils/registry';
 import { TYPES } from '../../base/types';
-import { SButton } from './model';
+import { SButtonImpl } from './model';
 import { isInjectable } from '../../utils/inversify';
 
 export interface IButtonHandler {
-    buttonPressed(button: SButton): (Action | Promise<Action>)[]
+    buttonPressed(button: SButtonImpl): (Action | Promise<Action>)[]
 }
 
 /** @deprecated deprecated since 0.12.0 - please use `configureButtonHandler` */

--- a/packages/sprotty/src/features/button/model.ts
+++ b/packages/sprotty/src/features/button/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { boundsFeature, layoutableChildFeature, SShapeElement } from '../bounds/model';
+import { boundsFeature, layoutableChildFeature, SShapeElementImpl } from '../bounds/model';
 import { fadeFeature } from '../fade/model';
 import { SShapeElement as SShapeElementSchema } from 'sprotty-protocol';
 
@@ -23,8 +23,11 @@ export interface SButtonSchema extends SShapeElementSchema {
     enabled: boolean
 }
 
-export class SButton extends SShapeElement {
+export class SButtonImpl extends SShapeElementImpl {
     static readonly DEFAULT_FEATURES = [boundsFeature, layoutableChildFeature, fadeFeature];
 
     enabled = true;
 }
+
+/** @deprecated Use `SButtonImpl` instead. */
+export const SButton = SButtonImpl;

--- a/packages/sprotty/src/features/command-palette/command-palette.ts
+++ b/packages/sprotty/src/features/command-palette/command-palette.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from "inversify";
 import { Action, isAction } from 'sprotty-protocol/lib/actions';
 import { LabeledAction, isLabeledAction } from "../../base/actions/action";
 import { IActionDispatcherProvider } from "../../base/actions/action-dispatcher";
-import { SModelElement, SModelRoot } from "../../base/model/smodel";
+import { SModelElementImpl, SModelRootImpl } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
 import { AbstractUIExtension } from "../../base/ui-extensions/ui-extension";
 import { SetUIExtensionVisibilityAction } from "../../base/ui-extensions/ui-extension-registry";
@@ -61,7 +61,7 @@ export class CommandPalette extends AbstractUIExtension {
     public id() { return CommandPalette.ID; }
     public containerClass() { return "command-palette"; }
 
-    override show(root: Readonly<SModelRoot>, ...contextElementIds: string[]) {
+    override show(root: Readonly<SModelRootImpl>, ...contextElementIds: string[]) {
         super.show(root, ...contextElementIds);
         this.paletteIndex = 0;
         this.contextActions = undefined;
@@ -93,7 +93,7 @@ export class CommandPalette extends AbstractUIExtension {
         this.paletteIndex++;
     }
 
-    protected override onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRoot>, ...selectedElementIds: string[]) {
+    protected override onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRootImpl>, ...selectedElementIds: string[]) {
         let x = this.xOffset;
         let y = this.yOffset;
         const selectedElements = toArray(root.index.all().filter(e => isSelectable(e) && e.selected));
@@ -111,7 +111,7 @@ export class CommandPalette extends AbstractUIExtension {
         containerElement.style.width = `${this.defaultWidth}px`;
     }
 
-    protected autocompleteSettings(root: Readonly<SModelRoot>): AutocompleteSettings<LabeledAction> {
+    protected autocompleteSettings(root: Readonly<SModelRootImpl>): AutocompleteSettings<LabeledAction> {
         return {
             input: this.inputElement,
             emptyMsg: this.noCommandsMsg,
@@ -135,7 +135,7 @@ export class CommandPalette extends AbstractUIExtension {
         this.hide();
     }
 
-    protected updateAutoCompleteActions(update: (items: LabeledAction[]) => void, text: string, root: Readonly<SModelRoot>) {
+    protected updateAutoCompleteActions(update: (items: LabeledAction[]) => void, text: string, root: Readonly<SModelRootImpl>) {
         this.onLoading();
         if (this.contextActions) {
             update(this.filterActions(text, this.contextActions));
@@ -240,7 +240,7 @@ function espaceForRegExp(value: string): string {
 }
 
 export class CommandPaletteKeyListener extends KeyListener {
-    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'Escape')) {
             return [SetUIExtensionVisibilityAction.create({ extensionId: CommandPalette.ID, visible: false, contextElementsId: [] })];
         } else if (CommandPalette.isInvokePaletteKey(event)) {

--- a/packages/sprotty/src/features/context-menu/menu-providers.ts
+++ b/packages/sprotty/src/features/context-menu/menu-providers.ts
@@ -17,7 +17,7 @@
 import { injectable, multiInject, optional } from 'inversify';
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { MenuItem } from './context-menu-service';
-import { SModelRoot } from '../../base/model/smodel';
+import { SModelRootImpl } from '../../base/model/smodel';
 import { LabeledAction } from '../../base/actions/action';
 import { TYPES } from '../../base/types';
 import { isDeletable } from '../edit/delete';
@@ -25,7 +25,7 @@ import { isSelected } from '../select/model';
 import { DeleteElementAction } from 'sprotty-protocol';
 
 export interface IContextMenuItemProvider {
-    getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<LabeledAction[]>;
+    getItems(root: Readonly<SModelRootImpl>, lastMousePosition?: Point): Promise<LabeledAction[]>;
 }
 
 @injectable()
@@ -33,7 +33,7 @@ export class ContextMenuProviderRegistry implements IContextMenuItemProvider {
 
     constructor(@multiInject(TYPES.IContextMenuItemProvider) @optional() protected menuProviders: IContextMenuItemProvider[] = []) { }
 
-    getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point) {
+    getItems(root: Readonly<SModelRootImpl>, lastMousePosition?: Point) {
         const menues = this.menuProviders.map(provider => provider.getItems(root, lastMousePosition));
         return Promise.all(menues).then(this.flattenAndRestructure);
     }
@@ -67,7 +67,7 @@ export class ContextMenuProviderRegistry implements IContextMenuItemProvider {
 
 @injectable()
 export class DeleteContextMenuItemProvider implements IContextMenuItemProvider {
-    getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<MenuItem[]> {
+    getItems(root: Readonly<SModelRootImpl>, lastMousePosition?: Point): Promise<MenuItem[]> {
         const selectedElements = Array.from(root.index.all().filter(isSelected).filter(isDeletable));
         return Promise.resolve([
             {

--- a/packages/sprotty/src/features/context-menu/mouse-listener.ts
+++ b/packages/sprotty/src/features/context-menu/mouse-listener.ts
@@ -17,7 +17,7 @@
 import { inject } from "inversify";
 import { Action, SelectAction } from "sprotty-protocol/lib/actions";
 import { IActionDispatcher } from "../../base/actions/action-dispatcher";
-import { SModelElement } from "../../base/model/smodel";
+import { SModelElementImpl } from "../../base/model/smodel";
 import { findParentByFeature } from "../../base/model/smodel-utils";
 import { TYPES } from "../../base/types";
 import { MouseListener } from "../../base/views/mouse-tool";
@@ -33,12 +33,12 @@ export class ContextMenuMouseListener extends MouseListener {
         super();
     }
 
-    override contextMenu(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override contextMenu(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         this.showContextMenu(target, event);
         return [];
     }
 
-    protected async showContextMenu(target: SModelElement, event: MouseEvent): Promise<void> {
+    protected async showContextMenu(target: SModelElementImpl, event: MouseEvent): Promise<void> {
         let menuService: IContextMenuService;
         try {
             menuService = await this.contextMenuService();

--- a/packages/sprotty/src/features/decoration/decoration-placer.ts
+++ b/packages/sprotty/src/features/decoration/decoration-placer.ts
@@ -16,12 +16,12 @@
 
 import { injectable, inject } from "inversify";
 import { VNode } from "snabbdom";
-import { SModelElement, SChildElement } from "../../base/model/smodel";
+import { SModelElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
 import { isDecoration, Decoration } from "./model";
 import { setAttr } from "../../base/views/vnode-utils";
 import { isSizeable } from "../bounds/model";
-import { SRoutableElement } from "../routing/model";
+import { SRoutableElementImpl } from "../routing/model";
 import { EdgeRouterRegistry } from "../routing/routing";
 import { Point } from "sprotty-protocol";
 
@@ -30,7 +30,7 @@ export class DecorationPlacer implements IVNodePostprocessor {
 
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         if (isDecoration(element)) {
             const position = this.getPosition(element);
             const translate = 'translate(' + position.x + ', ' + position.y + ')';
@@ -39,8 +39,8 @@ export class DecorationPlacer implements IVNodePostprocessor {
         return vnode;
     }
 
-    protected getPosition(element: SModelElement & Decoration): Point {
-        if (element instanceof SChildElement && element.parent instanceof SRoutableElement) {
+    protected getPosition(element: SModelElementImpl & Decoration): Point {
+        if (element instanceof SChildElementImpl && element.parent instanceof SRoutableElementImpl) {
             const route =  this.edgeRouterRegistry.route(element.parent);
             if (route.length > 1) {
                 const index = Math.floor(0.5  * (route.length - 1));

--- a/packages/sprotty/src/features/decoration/model.ts
+++ b/packages/sprotty/src/features/decoration/model.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import { SModelExtension } from '../../base/model/smodel-extension';
-import { SModelElement } from '../../base/model/smodel';
-import { SShapeElement, boundsFeature } from '../bounds/model';
+import { SModelElementImpl } from '../../base/model/smodel';
+import { SShapeElementImpl, boundsFeature } from '../bounds/model';
 import { hoverFeedbackFeature, popupFeature } from '../hover/model';
 
 export const decorationFeature = Symbol('decorationFeature');
@@ -24,11 +24,11 @@ export const decorationFeature = Symbol('decorationFeature');
 export interface Decoration extends SModelExtension {
 }
 
-export function isDecoration<T extends SModelElement>(e: T): e is T & Decoration {
+export function isDecoration<T extends SModelElementImpl>(e: T): e is T & Decoration {
     return e.hasFeature(decorationFeature);
 }
 
-export class SDecoration extends SShapeElement implements Decoration {
+export class SDecoration extends SShapeElementImpl implements Decoration {
     static readonly DEFAULT_FEATURES = [decorationFeature, boundsFeature, hoverFeedbackFeature, popupFeature];
 }
 

--- a/packages/sprotty/src/features/edge-layout/edge-layout.ts
+++ b/packages/sprotty/src/features/edge-layout/edge-layout.ts
@@ -17,10 +17,10 @@
 import { injectable, inject } from "inversify";
 import { VNode } from "snabbdom";
 import { Bounds, Point, toDegrees } from "sprotty-protocol/lib/utils/geometry";
-import { SModelElement, SChildElement } from "../../base/model/smodel";
+import { SModelElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
 import { setAttr } from "../../base/views/vnode-utils";
-import { SEdge } from "../../graph/sgraph";
+import { SEdgeImpl } from "../../graph/sgraph";
 import { Orientation } from "../../utils/geometry";
 import { isAlignable, BoundsAware } from "../bounds/model";
 import { DEFAULT_EDGE_PLACEMENT, isEdgeLayoutable, EdgeLayoutable, EdgePlacement } from "./model";
@@ -31,8 +31,8 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
 
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
-        if (isEdgeLayoutable(element) && element.parent instanceof SEdge) {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
+        if (isEdgeLayoutable(element) && element.parent instanceof SEdgeImpl) {
             if (element.bounds !== Bounds.EMPTY) {
                 const placement = this.getEdgePlacement(element);
                 const edge = element.parent;
@@ -66,7 +66,7 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
         return vnode;
     }
 
-    protected getRotatedAlignment(element: EdgeLayoutable & SModelElement & BoundsAware, placement: EdgePlacement, flip: boolean) {
+    protected getRotatedAlignment(element: EdgeLayoutable & SModelElementImpl & BoundsAware, placement: EdgePlacement, flip: boolean) {
         let x = isAlignable(element) ? element.alignment.x : 0;
         let y = isAlignable(element) ? element.alignment.y : 0;
         const bounds = element.bounds;
@@ -108,14 +108,14 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
         return { x, y };
     }
 
-    protected getEdgePlacement(element: SModelElement): EdgePlacement {
+    protected getEdgePlacement(element: SModelElementImpl): EdgePlacement {
         let current = element;
         const allPlacements: EdgePlacement[] = [];
         while (current !== undefined) {
             const placement = (current as any).edgePlacement;
             if (placement !== undefined)
                 allPlacements.push(placement);
-            if (current instanceof SChildElement)
+            if (current instanceof SChildElementImpl)
                 current = current.parent;
             else
                 break;
@@ -124,7 +124,7 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
             (a, b) => { return {...a, ...b}; }, DEFAULT_EDGE_PLACEMENT);
     }
 
-    protected getAlignment(label: EdgeLayoutable & SModelElement & BoundsAware, placement: EdgePlacement, angle: number): Point {
+    protected getAlignment(label: EdgeLayoutable & SModelElementImpl & BoundsAware, placement: EdgePlacement, angle: number): Point {
         const bounds = label.bounds;
         const x = isAlignable(label) ? label.alignment.x - bounds.width : 0;
         const y = isAlignable(label) ? label.alignment.y - bounds.height : 0;

--- a/packages/sprotty/src/features/edge-layout/model.ts
+++ b/packages/sprotty/src/features/edge-layout/model.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import { SModelExtension } from '../../base/model/smodel-extension';
-import { SModelElement, SChildElement } from '../../base/model/smodel';
+import { SModelElementImpl, SChildElementImpl } from '../../base/model/smodel';
 import { BoundsAware, isBoundsAware } from '../bounds/model';
-import { SRoutableElement } from '../routing/model';
+import { SRoutableElementImpl } from '../routing/model';
 
 export const edgeLayoutFeature = Symbol('edgeLayout');
 
@@ -25,15 +25,15 @@ export interface EdgeLayoutable extends SModelExtension {
     edgePlacement: EdgePlacement
 }
 
-export function isEdgeLayoutable<T extends SModelElement>(element: T): element is T & SChildElement & BoundsAware & EdgeLayoutable {
-    return element instanceof SChildElement
-        && element.parent instanceof SRoutableElement
+export function isEdgeLayoutable<T extends SModelElementImpl>(element: T): element is T & SChildElementImpl & BoundsAware & EdgeLayoutable {
+    return element instanceof SChildElementImpl
+        && element.parent instanceof SRoutableElementImpl
         && checkEdgeLayoutable(element)
         && isBoundsAware(element)
         && element.hasFeature(edgeLayoutFeature);
 }
 
-function checkEdgeLayoutable(element: SChildElement): element is SChildElement & EdgeLayoutable{
+function checkEdgeLayoutable(element: SChildElementImpl): element is SChildElementImpl & EdgeLayoutable{
     return 'edgePlacement' in element;
 }
 

--- a/packages/sprotty/src/features/edit/create-on-drag.ts
+++ b/packages/sprotty/src/features/edit/create-on-drag.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Action } from "sprotty-protocol/lib/actions";
-import { SModelElement } from "../../base/model/smodel";
+import { SModelElementImpl } from "../../base/model/smodel";
 import { SModelExtension } from "../../base/model/smodel-extension";
 
 export const creatingOnDragFeature = Symbol('creatingOnDragFeature');
@@ -24,6 +24,6 @@ export interface CreatingOnDrag extends SModelExtension {
     createAction(id: string): Action;
 }
 
-export function isCreatingOnDrag<T extends SModelElement>(element: T): element is T & CreatingOnDrag {
+export function isCreatingOnDrag<T extends SModelElementImpl>(element: T): element is T & CreatingOnDrag {
     return element.hasFeature(creatingOnDragFeature) && (element as any).createAction !== undefined;
 }

--- a/packages/sprotty/src/features/edit/create.ts
+++ b/packages/sprotty/src/features/edit/create.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from 'inversify';
 import { Action, CreateElementAction as ProtocolCreateElementAction } from 'sprotty-protocol/lib/actions';
 import { SModelElement as SModelElementSchema } from 'sprotty-protocol/lib/model';
 import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
-import { SParentElement, SChildElement } from '../../base/model/smodel';
+import { SParentElementImpl, SChildElementImpl } from '../../base/model/smodel';
 import { TYPES } from '../../base/types';
 
 /**
@@ -47,8 +47,8 @@ export namespace CreateElementAction {
 export class CreateElementCommand extends Command {
     static readonly KIND = ProtocolCreateElementAction.KIND;
 
-    container: SParentElement;
-    newElement: SChildElement;
+    container: SParentElementImpl;
+    newElement: SChildElementImpl;
 
     constructor(@inject(TYPES.Action) protected readonly action: ProtocolCreateElementAction) {
         super();
@@ -56,7 +56,7 @@ export class CreateElementCommand extends Command {
 
     execute(context: CommandExecutionContext): CommandReturn {
         const container = context.root.index.getById(this.action.containerId);
-        if (container instanceof SParentElement) {
+        if (container instanceof SParentElementImpl) {
             this.container = container;
             this.newElement = context.modelFactory.createElement(this.action.elementSchema);
             this.container.add(this.newElement);

--- a/packages/sprotty/src/features/edit/delete.ts
+++ b/packages/sprotty/src/features/edit/delete.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from 'inversify';
 import { Action, DeleteElementAction as ProtocolDeleteElementAction} from 'sprotty-protocol/lib/actions';
 import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
-import { SModelElement, SParentElement, SChildElement } from '../../base/model/smodel';
+import { SModelElementImpl, SParentElementImpl, SChildElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { TYPES } from '../../base/types';
 
@@ -26,8 +26,8 @@ export const deletableFeature = Symbol('deletableFeature');
 export interface Deletable extends SModelExtension {
 }
 
-export function isDeletable<T extends SModelElement>(element: T): element is T & Deletable & SChildElement {
-    return element instanceof SChildElement && element.hasFeature(deletableFeature);
+export function isDeletable<T extends SModelElementImpl>(element: T): element is T & Deletable & SChildElementImpl {
+    return element instanceof SChildElementImpl && element.hasFeature(deletableFeature);
 }
 
 /**
@@ -51,8 +51,8 @@ export namespace DeleteElementAction {
 }
 
 export class ResolvedDelete {
-    child: SChildElement;
-    parent: SParentElement;
+    child: SChildElementImpl;
+    parent: SParentElementImpl;
 }
 
 @injectable()

--- a/packages/sprotty/src/features/edit/di.config.ts
+++ b/packages/sprotty/src/features/edit/di.config.ts
@@ -19,7 +19,7 @@ import { TYPES } from "../../base/types";
 import { configureCommand } from "../../base/commands/command-registration";
 import { configureActionHandler } from "../../base/actions/action-handler";
 import { configureModelElement } from "../../base/views/view";
-import { SDanglingAnchor } from "../../features/routing/model";
+import { SDanglingAnchorImpl } from "../../features/routing/model";
 import { EmptyGroupView } from "../../lib/svg-views";
 import { DeleteElementCommand } from "./delete";
 import { EditLabelMouseListener, ApplyLabelEditCommand, EditLabelKeyListener, EditLabelAction } from "./edit-label";
@@ -32,7 +32,7 @@ export const edgeEditModule = new ContainerModule((bind, _unbind, isBound) => {
     configureCommand(context, SwitchEditModeCommand);
     configureCommand(context, ReconnectCommand);
     configureCommand(context, DeleteElementCommand);
-    configureModelElement(context, 'dangling-anchor', SDanglingAnchor, EmptyGroupView);
+    configureModelElement(context, 'dangling-anchor', SDanglingAnchorImpl, EmptyGroupView);
 });
 
 export const labelEditModule = new ContainerModule((bind, _unbind, isBound) => {

--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -19,7 +19,7 @@ import { Action, ApplyLabelEditAction } from 'sprotty-protocol/lib/actions';
 import { IActionDispatcherProvider } from '../../base/actions/action-dispatcher';
 import { IActionHandler } from '../../base/actions/action-handler';
 import { ICommand } from '../../base/commands/command';
-import { SModelElement, SModelRoot } from '../../base/model/smodel';
+import { SModelElementImpl, SModelRootImpl } from '../../base/model/smodel';
 import { TYPES } from '../../base/types';
 import { AbstractUIExtension } from '../../base/ui-extensions/ui-extension';
 import { SetUIExtensionVisibilityAction } from '../../base/ui-extensions/ui-extension-registry';
@@ -60,7 +60,7 @@ export class EditLabelUI extends AbstractUIExtension {
     protected inputElement: HTMLInputElement;
     protected textAreaElement: HTMLTextAreaElement;
 
-    protected label?: EditableLabel & SModelElement;
+    protected label?: EditableLabel & SModelElementImpl;
     protected labelElement: HTMLElement | null;
     protected validationTimeout?: number = undefined;
     protected isActive: boolean = false;
@@ -176,7 +176,7 @@ export class EditLabelUI extends AbstractUIExtension {
         }
     }
 
-    override show(root: Readonly<SModelRoot>, ...contextElementIds: string[]) {
+    override show(root: Readonly<SModelRootImpl>, ...contextElementIds: string[]) {
         if (!hasEditableLabel(contextElementIds, root) || this.isActive) {
             return;
         }
@@ -196,7 +196,7 @@ export class EditLabelUI extends AbstractUIExtension {
         }
     }
 
-    protected override onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRoot>, ...contextElementIds: string[]) {
+    protected override onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRootImpl>, ...contextElementIds: string[]) {
         this.label = getEditableLabels(contextElementIds, root)[0];
         this.previousLabelContent = this.label.text;
         this.setPosition(containerElement);
@@ -260,11 +260,11 @@ export class EditLabelUI extends AbstractUIExtension {
     }
 }
 
-function hasEditableLabel(contextElementIds: string[], root: Readonly<SModelRoot>) {
+function hasEditableLabel(contextElementIds: string[], root: Readonly<SModelRootImpl>) {
     return getEditableLabels(contextElementIds, root).length === 1;
 }
 
-function getEditableLabels(contextElementIds: string[], root: Readonly<SModelRoot>) {
+function getEditableLabels(contextElementIds: string[], root: Readonly<SModelRootImpl>) {
     return contextElementIds.map(id => root.index.getById(id)).filter(isEditableLabel);
 }
 

--- a/packages/sprotty/src/features/edit/edit-label.ts
+++ b/packages/sprotty/src/features/edit/edit-label.ts
@@ -17,7 +17,7 @@
 import { inject } from 'inversify';
 import { Action, isAction, ApplyLabelEditAction as ProtocolApplyLabelEditAction } from 'sprotty-protocol/lib/actions';
 import { CommandExecutionContext, CommandReturn, Command } from '../../base/commands/command';
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { TYPES } from '../../base/types';
 import { MouseListener } from '../../base/views/mouse-tool';
 import { KeyListener } from '../../base/views/key-tool';
@@ -113,7 +113,7 @@ export class ApplyLabelEditCommand extends Command {
 }
 
 export interface IEditLabelValidator {
-    validate(value: string, label: EditableLabel & SModelElement): Promise<EditLabelValidationResult>;
+    validate(value: string, label: EditableLabel & SModelElementImpl): Promise<EditLabelValidationResult>;
 }
 
 export interface EditLabelValidationResult {
@@ -124,7 +124,7 @@ export interface EditLabelValidationResult {
 export type Severity = 'ok' | 'warning' | 'error';
 
 export class EditLabelMouseListener extends MouseListener {
-    override doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override doubleClick(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         const editableLabel = getEditableLabel(target);
         if (editableLabel) {
             return [EditLabelAction.create(editableLabel.id)];
@@ -134,11 +134,11 @@ export class EditLabelMouseListener extends MouseListener {
 }
 
 export class EditLabelKeyListener extends KeyListener {
-    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'F2')) {
             const editableLabels = toArray(element.index.all()
                 .filter(e => isSelectable(e) && e.selected)).map(getEditableLabel)
-                .filter((e): e is EditableLabel & SModelElement => e !== undefined);
+                .filter((e): e is EditableLabel & SModelElementImpl => e !== undefined);
             if (editableLabels.length === 1) {
                 return [EditLabelAction.create(editableLabels[0].id)];
             }
@@ -147,7 +147,7 @@ export class EditLabelKeyListener extends KeyListener {
     }
 }
 
-export function getEditableLabel(element: SModelElement): EditableLabel & SModelElement | undefined {
+export function getEditableLabel(element: SModelElementImpl): EditableLabel & SModelElementImpl | undefined {
     if (isEditableLabel(element)) {
         return element;
     } else if (isWithEditableLabel(element) && element.editableLabel) {

--- a/packages/sprotty/src/features/edit/model.ts
+++ b/packages/sprotty/src/features/edit/model.ts
@@ -15,14 +15,14 @@
  ********************************************************************************/
 
 import { Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
-import { SRoutableElement } from '../routing/model';
+import { SRoutableElementImpl } from '../routing/model';
 
 export const editFeature = Symbol('editFeature');
 
-export function canEditRouting(element: SModelElement): element is SRoutableElement {
-    return element instanceof SRoutableElement && element.hasFeature(editFeature);
+export function canEditRouting(element: SModelElementImpl): element is SRoutableElementImpl {
+    return element instanceof SRoutableElementImpl && element.hasFeature(editFeature);
 }
 
 export const editLabelFeature = Symbol('editLabelFeature');
@@ -34,16 +34,16 @@ export interface EditableLabel extends SModelExtension {
     readonly editControlPositionCorrection?: Point;
 }
 
-export function isEditableLabel<T extends SModelElement>(element: T): element is T & EditableLabel {
+export function isEditableLabel<T extends SModelElementImpl>(element: T): element is T & EditableLabel {
     return 'text' in element && element.hasFeature(editLabelFeature);
 }
 
 export const withEditLabelFeature = Symbol('withEditLabelFeature');
 
 export interface WithEditableLabel extends SModelExtension {
-    readonly editableLabel?: EditableLabel & SModelElement;
+    readonly editableLabel?: EditableLabel & SModelElementImpl;
 }
 
-export function isWithEditableLabel<T extends SModelElement>(element: T): element is T & WithEditableLabel {
+export function isWithEditableLabel<T extends SModelElementImpl>(element: T): element is T & WithEditableLabel {
     return 'editableLabel' in element && element.hasFeature(withEditLabelFeature);
 }

--- a/packages/sprotty/src/features/edit/reconnect.ts
+++ b/packages/sprotty/src/features/edit/reconnect.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from 'inversify';
 import { Action, ReconnectAction as ProtocolReconnectAction} from 'sprotty-protocol/lib/actions';
 import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
 import { TYPES } from '../../base/types';
-import { SRoutableElement } from '../routing/model';
+import { SRoutableElementImpl } from '../routing/model';
 import { EdgeMemento, EdgeRouterRegistry } from '../routing/routing';
 
 /**
@@ -63,7 +63,7 @@ export class ReconnectCommand extends Command {
     private doExecute(context: CommandExecutionContext) {
         const index = context.root.index;
         const edge = index.getById(this.action.routableId);
-        if (edge instanceof SRoutableElement) {
+        if (edge instanceof SRoutableElementImpl) {
             const router = this.edgeRouterRegistry.get(edge.routerKind);
             const before = router.takeSnapshot(edge);
             router.applyReconnect(edge, this.action.newSourceId, this.action.newTargetId);

--- a/packages/sprotty/src/features/expand/expand.ts
+++ b/packages/sprotty/src/features/expand/expand.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Action, CollapseExpandAction as ProtocolCollapseExpandAction, CollapseExpandAllAction as ProtocolCollapseExpandAllAction} from 'sprotty-protocol/lib/actions';
-import { SButton } from '../button/model';
+import { SButtonImpl } from '../button/model';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { isExpandable } from './model';
 import { IButtonHandler } from '../button/button-handler';
@@ -56,7 +56,7 @@ export class CollapseExpandAllAction implements Action,ProtocolCollapseExpandAll
 export class ExpandButtonHandler implements IButtonHandler {
     static TYPE = 'button:expand';
 
-    buttonPressed(button: SButton): Action[] {
+    buttonPressed(button: SButtonImpl): Action[] {
         const expandable = findParentByFeature(button, isExpandable);
         if (expandable !== undefined) {
             return [ ProtocolCollapseExpandAction.create({

--- a/packages/sprotty/src/features/expand/model.ts
+++ b/packages/sprotty/src/features/expand/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 
 export const expandFeature = Symbol('expandFeature');
@@ -26,6 +26,6 @@ export interface Expandable extends SModelExtension {
     expanded: boolean
 }
 
-export function isExpandable(element: SModelElement): element is SModelElement & Expandable {
+export function isExpandable(element: SModelElementImpl): element is SModelElementImpl & Expandable {
     return element.hasFeature(expandFeature) && 'expanded' in element;
 }

--- a/packages/sprotty/src/features/expand/views.tsx
+++ b/packages/sprotty/src/features/expand/views.tsx
@@ -21,12 +21,12 @@ import { VNode } from 'snabbdom';
 import { IView, RenderingContext } from '../../base/views/view';
 import { isExpandable } from './model';
 import { findParentByFeature } from '../../base/model/smodel-utils';
-import { SButton } from '../button/model';
+import { SButtonImpl } from '../button/model';
 import { injectable } from 'inversify';
 
 @injectable()
 export class ExpandButtonView implements IView {
-    render(button: SButton, context: RenderingContext): VNode {
+    render(button: SButtonImpl, context: RenderingContext): VNode {
         const expandable = findParentByFeature(button, isExpandable);
         const path = (expandable !== undefined && expandable.expanded)
             ? 'M 1,5 L 8,12 L 15,5 Z'

--- a/packages/sprotty/src/features/export/export.ts
+++ b/packages/sprotty/src/features/export/export.ts
@@ -20,7 +20,7 @@ import { Action, generateRequestId, RequestAction } from "sprotty-protocol/lib/a
 import { CommandExecutionContext, HiddenCommand, CommandResult } from '../../base/commands/command';
 import { IVNodePostprocessor } from '../../base/views/vnode-postprocessor';
 import { isSelectable } from '../select/model';
-import { SModelElement, SModelRoot } from '../../base/model/smodel';
+import { SModelElementImpl, SModelRootImpl } from '../../base/model/smodel';
 import { KeyListener } from '../../base/views/key-tool';
 import { matchesKeystroke } from '../../utils/keyboard';
 import { isExportable } from './model';
@@ -31,7 +31,7 @@ import { TYPES } from '../../base/types';
 
 @injectable()
 export class ExportSvgKeyListener extends KeyListener {
-    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyE', 'ctrlCmd', 'shift'))
             return [ RequestExportSvgAction.create() ];
         else
@@ -91,12 +91,12 @@ export class ExportSvgCommand extends HiddenCommand {
 @injectable()
 export class ExportSvgPostprocessor implements IVNodePostprocessor {
 
-    root: SModelRoot;
+    root: SModelRootImpl;
 
     @inject(TYPES.SvgExporter) protected svgExporter: SvgExporter;
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
-        if (element instanceof SModelRoot)
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
+        if (element instanceof SModelRootImpl)
             this.root = element;
         return vnode;
     }

--- a/packages/sprotty/src/features/export/model.ts
+++ b/packages/sprotty/src/features/export/model.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 
 export const exportFeature = Symbol('exportFeature');
 
-export function isExportable(element: SModelElement): boolean {
+export function isExportable(element: SModelElementImpl): boolean {
      return element.hasFeature(exportFeature);
 }

--- a/packages/sprotty/src/features/export/svg-exporter.ts
+++ b/packages/sprotty/src/features/export/svg-exporter.ts
@@ -21,7 +21,7 @@ import { ViewerOptions } from '../../base/views/viewer-options';
 import { isBoundsAware } from '../bounds/model';
 import { ActionDispatcher } from '../../base/actions/action-dispatcher';
 import { TYPES } from '../../base/types';
-import { SModelRoot } from '../../base/model/smodel';
+import { SModelRootImpl } from '../../base/model/smodel';
 import { ILogger } from '../../utils/logging';
 
 export interface ExportSvgAction extends ResponseAction {
@@ -48,7 +48,7 @@ export class SvgExporter {
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: ActionDispatcher;
     @inject(TYPES.ILogger) protected log: ILogger;
 
-    export(root: SModelRoot, request?: RequestAction<ExportSvgAction>): void {
+    export(root: SModelRootImpl, request?: RequestAction<ExportSvgAction>): void {
         if (typeof document !== 'undefined') {
             const div = document.getElementById(this.options.hiddenDiv);
             if (div !== null && div.firstElementChild && div.firstElementChild.tagName === 'svg') {
@@ -59,7 +59,7 @@ export class SvgExporter {
         }
     }
 
-    protected createSvg(svgElementOrig: SVGSVGElement, root: SModelRoot): string {
+    protected createSvg(svgElementOrig: SVGSVGElement, root: SModelRootImpl): string {
         const serializer = new XMLSerializer();
         const svgCopy = serializer.serializeToString(svgElementOrig);
         const iframe: HTMLIFrameElement = document.createElement('iframe');
@@ -105,7 +105,7 @@ export class SvgExporter {
         }
     }
 
-    protected getBounds(root: SModelRoot) {
+    protected getBounds(root: SModelRootImpl) {
         const allBounds: Bounds[] = [ Bounds.EMPTY ];
         root.children.forEach(element => {
             if (isBoundsAware(element)) {

--- a/packages/sprotty/src/features/fade/fade.ts
+++ b/packages/sprotty/src/features/fade/fade.ts
@@ -18,33 +18,33 @@ import { injectable } from "inversify";
 import { VNode } from "snabbdom";
 import { Animation } from "../../base/animations/animation";
 import { CommandExecutionContext } from "../../base/commands/command";
-import { SModelRoot, SModelElement, SChildElement } from "../../base/model/smodel";
+import { SModelRootImpl, SModelElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
 import { setAttr } from "../../base/views/vnode-utils";
 import { Fadeable, isFadeable } from "./model";
 
 export interface ResolvedElementFade {
-    element: SModelElement & Fadeable
+    element: SModelElementImpl & Fadeable
     type: 'in' | 'out'
 }
 
 export class FadeAnimation extends Animation {
 
-    constructor(protected model: SModelRoot,
+    constructor(protected model: SModelRootImpl,
                 public elementFades: ResolvedElementFade[],
                 context: CommandExecutionContext,
                 protected removeAfterFadeOut: boolean = false) {
         super(context);
     }
 
-    tween(t: number, context: CommandExecutionContext): SModelRoot {
+    tween(t: number, context: CommandExecutionContext): SModelRootImpl {
         for (const elementFade of this.elementFades) {
             const element = elementFade.element;
             if (elementFade.type === 'in') {
                 element.opacity = t;
             } else if (elementFade.type === 'out') {
                 element.opacity = 1 - t;
-                if (t === 1 && this.removeAfterFadeOut && element instanceof SChildElement) {
+                if (t === 1 && this.removeAfterFadeOut && element instanceof SChildElementImpl) {
                     element.parent.remove(element);
                 }
             }
@@ -57,7 +57,7 @@ export class FadeAnimation extends Animation {
 @injectable()
 export class ElementFader implements IVNodePostprocessor {
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         if (isFadeable(element) && element.opacity !== 1) {
             setAttr(vnode, 'opacity', element.opacity);
         }

--- a/packages/sprotty/src/features/fade/model.ts
+++ b/packages/sprotty/src/features/fade/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 
 export const fadeFeature = Symbol('fadeFeature');
@@ -23,6 +23,6 @@ export interface Fadeable extends SModelExtension {
     opacity: number
 }
 
-export function isFadeable(element: SModelElement): element is SModelElement & Fadeable {
+export function isFadeable(element: SModelElementImpl): element is SModelElementImpl & Fadeable {
     return element.hasFeature(fadeFeature) && (element as any)['opacity'] !== undefined;
 }

--- a/packages/sprotty/src/features/hover/model.ts
+++ b/packages/sprotty/src/features/hover/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 
 export const hoverFeedbackFeature = Symbol('hoverFeedbackFeature');
@@ -23,12 +23,12 @@ export interface Hoverable extends SModelExtension {
     hoverFeedback: boolean
 }
 
-export function isHoverable(element: SModelElement): element is SModelElement & Hoverable {
+export function isHoverable(element: SModelElementImpl): element is SModelElementImpl & Hoverable {
     return element.hasFeature(hoverFeedbackFeature);
 }
 
 export const popupFeature = Symbol('popupFeature');
 
-export function hasPopupFeature(element: SModelElement): boolean {
+export function hasPopupFeature(element: SModelElementImpl): boolean {
     return element.hasFeature(popupFeature);
 }

--- a/packages/sprotty/src/features/hover/popup-position-updater.ts
+++ b/packages/sprotty/src/features/hover/popup-position-updater.ts
@@ -19,14 +19,14 @@ import { VNode } from "snabbdom";
 import { TYPES } from "../../base/types";
 import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
 import { ViewerOptions } from "../../base/views/viewer-options";
-import { SModelElement } from "../../base/model/smodel";
+import { SModelElementImpl } from "../../base/model/smodel";
 
 @injectable()
 export class PopupPositionUpdater implements IVNodePostprocessor {
 
     @inject(TYPES.ViewerOptions) protected options: ViewerOptions;
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, element: SModelElementImpl): VNode {
         return vnode;
     }
 

--- a/packages/sprotty/src/features/move/model.ts
+++ b/packages/sprotty/src/features/move/model.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 
 export const moveFeature = Symbol('moveFeature');
@@ -28,10 +28,10 @@ export interface Locateable extends SModelExtension {
     position: Point
 }
 
-export function isLocateable(element: SModelElement): element is SModelElement & Locateable {
+export function isLocateable(element: SModelElementImpl): element is SModelElementImpl & Locateable {
     return (element as any)['position'] !== undefined;
 }
 
-export function isMoveable(element: SModelElement): element is SModelElement & Locateable {
+export function isMoveable(element: SModelElementImpl): element is SModelElementImpl & Locateable {
     return element.hasFeature(moveFeature) && isLocateable(element);
 }

--- a/packages/sprotty/src/features/move/snap.ts
+++ b/packages/sprotty/src/features/move/snap.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from "inversify";
 import { Point } from "sprotty-protocol/lib/utils/geometry";
-import { SModelElement } from "../../base/model/smodel";
+import { SModelElementImpl } from "../../base/model/smodel";
 import { isBoundsAware } from "../bounds/model";
 
 /**
@@ -26,7 +26,7 @@ export interface ISnapper {
     /**
      * @retruns the closest snapped position that for the `element` located at `position`
      */
-    snap(position: Point, element: SModelElement): Point
+    snap(position: Point, element: SModelElementImpl): Point
 }
 
 /**
@@ -43,7 +43,7 @@ export class CenterGridSnapper implements ISnapper {
         return 10;
     }
 
-    snap(position: Point, element: SModelElement): Point {
+    snap(position: Point, element: SModelElementImpl): Point {
         if (element && isBoundsAware(element))
             return {
                 x: Math.round((position.x + 0.5 * element.bounds.width) / this.gridX) * this.gridX - 0.5 * element.bounds.width,

--- a/packages/sprotty/src/features/nameable/model.ts
+++ b/packages/sprotty/src/features/nameable/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 
 export const nameFeature = Symbol('nameableFeature');
@@ -23,11 +23,11 @@ export interface Nameable extends SModelExtension {
     name: string
 }
 
-export function isNameable(element: SModelElement): element is SModelElement & Nameable {
+export function isNameable(element: SModelElementImpl): element is SModelElementImpl & Nameable {
     return element.hasFeature(nameFeature);
 }
 
-export function name(element: SModelElement): string|undefined {
+export function name(element: SModelElementImpl): string|undefined {
     if (isNameable(element)) {
         return element.name;
     } else {

--- a/packages/sprotty/src/features/open/model.ts
+++ b/packages/sprotty/src/features/open/model.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 
 export const openFeature = Symbol('openFeature');
 
-export function isOpenable(element: SModelElement): element is SModelElement  {
+export function isOpenable(element: SModelElementImpl): element is SModelElementImpl  {
     return element.hasFeature(openFeature);
 }

--- a/packages/sprotty/src/features/open/open.ts
+++ b/packages/sprotty/src/features/open/open.ts
@@ -16,13 +16,13 @@
 
 import { Action, OpenAction } from 'sprotty-protocol/lib/actions';
 import { MouseListener } from '../../base/views/mouse-tool';
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { isOpenable } from './model';
 
 
 export class OpenMouseListener extends MouseListener {
-    override doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override doubleClick(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         const openableTarget = findParentByFeature(target, isOpenable);
         if (openableTarget !== undefined) {
             return [ OpenAction.create(openableTarget.id) ];

--- a/packages/sprotty/src/features/projection/model.ts
+++ b/packages/sprotty/src/features/projection/model.ts
@@ -17,7 +17,7 @@
 import { Viewport } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension } from 'sprotty-protocol/lib/utils/geometry';
 import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
-import { SChildElement, SModelRoot, SParentElement } from '../../base/model/smodel';
+import { SChildElementImpl, SModelRootImpl, SParentElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { transformToRootBounds } from '../../base/model/smodel-utils';
 import { isBoundsAware } from '../bounds/model';
@@ -48,7 +48,7 @@ export interface ViewProjection {
 /**
  * Gather all projections of elements contained in the given parent element.
  */
-export function getProjections(parent: Readonly<SParentElement>): ViewProjection[] | undefined {
+export function getProjections(parent: Readonly<SParentElementImpl>): ViewProjection[] | undefined {
     let result: ViewProjection[] | undefined;
     for (const child of parent.children) {
         if (isProjectable(child) && child.projectionCssClasses.length > 0) {
@@ -83,7 +83,7 @@ export function getProjections(parent: Readonly<SParentElement>): ViewProjection
 /**
  * Compute the projected bounds of the given model element, that is the absolute position in the diagram.
  */
-export function getProjectedBounds(model: Readonly<SChildElement & Projectable>): Bounds | undefined {
+export function getProjectedBounds(model: Readonly<SChildElementImpl & Projectable>): Bounds | undefined {
     const parent = model.parent;
     if (model.projectedBounds) {
         let bounds = model.projectedBounds;
@@ -105,7 +105,7 @@ const MAX_COORD = 1_000_000_000;
  * Determine the total bounds of a model; this takes the viewport into consideration
  * so it can be shown in the projections.
  */
-export function getModelBounds(model: SModelRoot & Viewport): Bounds | undefined {
+export function getModelBounds(model: SModelRootImpl & Viewport): Bounds | undefined {
     let minX = MAX_COORD;
     let minY = MAX_COORD;
     let maxX = -MAX_COORD;

--- a/packages/sprotty/src/features/routing/anchor.ts
+++ b/packages/sprotty/src/features/routing/anchor.ts
@@ -18,7 +18,7 @@ import { injectable, multiInject } from "inversify";
 import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { TYPES } from "../../base/types";
 import { InstanceRegistry } from "../../utils/registry";
-import { SConnectableElement } from "./model";
+import { SConnectableElementImpl } from "./model";
 
 export const DIAMOND_ANCHOR_KIND = 'diamond';
 export const ELLIPTIC_ANCHOR_KIND = 'elliptic';
@@ -41,7 +41,7 @@ export interface IAnchorComputer {
      *               positive values should shift the anchor away from this element, negative values
      *               should shift the anchor more to the inside. Use this to adapt ot arrow heads.
      */
-    getAnchor(connectable: SConnectableElement, referencePoint: Point, offset?: number): Point;
+    getAnchor(connectable: SConnectableElementImpl, referencePoint: Point, offset?: number): Point;
 }
 
 

--- a/packages/sprotty/src/features/routing/manhattan-anchors.ts
+++ b/packages/sprotty/src/features/routing/manhattan-anchors.ts
@@ -18,7 +18,7 @@ import { Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
 import { Line, PointToPointLine, intersection } from "../../utils/geometry";
 import { RECTANGULAR_ANCHOR_KIND, IAnchorComputer, DIAMOND_ANCHOR_KIND, ELLIPTIC_ANCHOR_KIND } from "./anchor";
 import { ManhattanEdgeRouter } from "./manhattan-edge-router";
-import { SConnectableElement } from "./model";
+import { SConnectableElementImpl } from "./model";
 import { injectable } from "inversify";
 
 @injectable()
@@ -30,7 +30,7 @@ export class ManhattanRectangularAnchor implements IAnchorComputer {
         return ManhattanRectangularAnchor.KIND;
     }
 
-    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number): Point {
+    getAnchor(connectable: SConnectableElementImpl, refPoint: Point, offset: number): Point {
         const b = connectable.bounds;
         if (b.width <= 0 || b.height <= 0) {
             return b;
@@ -66,7 +66,7 @@ export class ManhattanDiamondAnchor implements IAnchorComputer {
         return ManhattanDiamondAnchor.KIND;
     }
 
-    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number = 0): Point {
+    getAnchor(connectable: SConnectableElementImpl, refPoint: Point, offset: number = 0): Point {
         const b = connectable.bounds;
         if (b.width <= 0 || b.height <= 0) {
             return b;
@@ -126,7 +126,7 @@ export class ManhattanEllipticAnchor implements IAnchorComputer {
         return ManhattanEllipticAnchor.KIND;
     }
 
-    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number = 0): Point {
+    getAnchor(connectable: SConnectableElementImpl, refPoint: Point, offset: number = 0): Point {
         const b = connectable.bounds;
         if (b.width <= 0 || b.height <= 0) {
             return b;

--- a/packages/sprotty/src/features/routing/model.ts
+++ b/packages/sprotty/src/features/routing/model.ts
@@ -15,16 +15,17 @@
  ********************************************************************************/
 
 import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SChildElement, SModelElement } from '../../base/model/smodel';
+import { SChildElementImpl, SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { FluentIterable } from '../../utils/iterable';
-import { SShapeElement } from '../bounds/model';
+import { SShapeElementImpl } from '../bounds/model';
 import { deletableFeature } from '../edit/delete';
 import { Selectable, selectFeature } from '../select/model';
 import { Hoverable, hoverFeedbackFeature } from '../hover/model';
 import { moveFeature } from '../move/model';
 
-export abstract class SRoutableElement extends SChildElement {
+export abstract class SRoutableElementImpl extends SChildElementImpl {
+
     routerKind?: string;
     routingPoints: Point[] = [];
     sourceId: string;
@@ -32,12 +33,12 @@ export abstract class SRoutableElement extends SChildElement {
     sourceAnchorCorrection?: number;
     targetAnchorCorrection?: number;
 
-    get source(): SConnectableElement | undefined {
-        return this.index.getById(this.sourceId) as SConnectableElement;
+    get source(): SConnectableElementImpl | undefined {
+        return this.index.getById(this.sourceId) as SConnectableElementImpl;
     }
 
-    get target(): SConnectableElement | undefined {
-        return this.index.getById(this.targetId) as SConnectableElement;
+    get target(): SConnectableElementImpl | undefined {
+        return this.index.getById(this.targetId) as SConnectableElementImpl;
     }
 
     get bounds(): Bounds {
@@ -51,20 +52,23 @@ export abstract class SRoutableElement extends SChildElement {
     }
 }
 
+/** @deprecated Use `SRoutableElementImpl` instead. */
+export const SRoutableElement = SRoutableElementImpl;
+
 export const connectableFeature = Symbol('connectableFeature');
 
 export interface Connectable extends SModelExtension {
-    canConnect(routable: SRoutableElement, role: 'source' | 'target'): boolean;
+    canConnect(routable: SRoutableElementImpl, role: 'source' | 'target'): boolean;
 }
 
-export function isConnectable<T extends SModelElement>(element: T): element is Connectable & T {
+export function isConnectable<T extends SModelElementImpl>(element: T): element is Connectable & T {
     return element.hasFeature(connectableFeature) && (element as any).canConnect;
 }
 
-export function getAbsoluteRouteBounds(model: Readonly<SRoutableElement>, route: Point[] = model.routingPoints): Bounds {
+export function getAbsoluteRouteBounds(model: Readonly<SRoutableElementImpl>, route: Point[] = model.routingPoints): Bounds {
     let bounds = getRouteBounds(route);
-    let current: SModelElement = model;
-    while (current instanceof SChildElement) {
+    let current: SModelElementImpl = model;
+    while (current instanceof SChildElementImpl) {
         const parent = current.parent;
         bounds = parent.localToParent(bounds);
         current = parent;
@@ -101,7 +105,7 @@ export function getRouteBounds(route: Point[]): Bounds {
  * or target element of an edge. There are two kinds of connectable elements: nodes (`SNode`) and
  * ports (`SPort`). A node represents a main entity, while a port is a connection point inside a node.
  */
-export abstract class SConnectableElement extends SShapeElement implements Connectable {
+export abstract class SConnectableElementImpl extends SShapeElementImpl implements Connectable {
 
     get anchorKind(): string | undefined{
          return undefined;
@@ -113,8 +117,8 @@ export abstract class SConnectableElement extends SShapeElement implements Conne
      * The incoming edges of this connectable element. They are resolved by the index, which must
      * be an `SGraphIndex` for efficient lookup.
      */
-    get incomingEdges(): FluentIterable<SRoutableElement> {
-        const allEdges = this.index.all().filter(e => e instanceof SRoutableElement) as FluentIterable<SRoutableElement>;
+    get incomingEdges(): FluentIterable<SRoutableElementImpl> {
+        const allEdges = this.index.all().filter(e => e instanceof SRoutableElementImpl) as FluentIterable<SRoutableElementImpl>;
         return allEdges.filter(e => e.targetId === this.id);
     }
 
@@ -122,20 +126,23 @@ export abstract class SConnectableElement extends SShapeElement implements Conne
      * The outgoing edges of this connectable element. They are resolved by the index, which must
      * be an `SGraphIndex` for efficient lookup.
      */
-    get outgoingEdges(): FluentIterable<SRoutableElement> {
-        const allEdges = this.index.all().filter(e => e instanceof SRoutableElement) as FluentIterable<SRoutableElement>;
+    get outgoingEdges(): FluentIterable<SRoutableElementImpl> {
+        const allEdges = this.index.all().filter(e => e instanceof SRoutableElementImpl) as FluentIterable<SRoutableElementImpl>;
         return allEdges.filter(e => e.sourceId === this.id);
     }
 
-    canConnect(routable: SRoutableElement, role: 'source' | 'target') {
+    canConnect(routable: SRoutableElementImpl, role: 'source' | 'target') {
         return true;
     }
 }
 
+/** @deprecated Use `SConnectableElementImpl` instead. */
+export const SConnectableElement = SConnectableElementImpl;
+
 export type RoutingHandleKind = 'junction' | 'line' | 'source' | 'target' | 'manhattan-50%' |
     'bezier-control-after' | 'bezier-control-before' | 'bezier-junction' | 'bezier-add' | 'bezier-remove';
 
-export class SRoutingHandle extends SChildElement implements Selectable, Hoverable {
+export class SRoutingHandleImpl extends SChildElementImpl implements Selectable, Hoverable {
     static readonly DEFAULT_FEATURES = [selectFeature, moveFeature, hoverFeedbackFeature];
 
     /**
@@ -151,21 +158,24 @@ export class SRoutingHandle extends SChildElement implements Selectable, Hoverab
 
     hoverFeedback: boolean = false;
     selected: boolean = false;
-    danglingAnchor?: SDanglingAnchor;
+    danglingAnchor?: SDanglingAnchorImpl;
 
     /**
      * SRoutingHandles are created using the constructor, so we hard-wire the
      * default features
      */
     override hasFeature(feature: symbol): boolean {
-        return SRoutingHandle.DEFAULT_FEATURES.indexOf(feature) !== -1;
+        return SRoutingHandleImpl.DEFAULT_FEATURES.indexOf(feature) !== -1;
     }
 }
 
-export class SDanglingAnchor extends SConnectableElement {
+/** @deprecated Use `SRoutingHandleImpl` instead. */
+export const SRoutingHandle = SRoutingHandleImpl;
+
+export class SDanglingAnchorImpl extends SConnectableElementImpl {
     static readonly DEFAULT_FEATURES = [deletableFeature];
 
-    original?: SModelElement;
+    original?: SModelElementImpl;
     override type = 'dangling-anchor';
 
     constructor() {
@@ -173,6 +183,9 @@ export class SDanglingAnchor extends SConnectableElement {
         this.size = { width: 0, height: 0 };
     }
 }
+
+/** @deprecated Use `SDanglingAnchorImpl` instead. */
+export const SDanglingAnchor = SDanglingAnchorImpl;
 
 export const edgeInProgressID = 'edge-in-progress';
 export const edgeInProgressTargetHandleID = edgeInProgressID + '-target-anchor';

--- a/packages/sprotty/src/features/routing/polyline-anchors.ts
+++ b/packages/sprotty/src/features/routing/polyline-anchors.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { IAnchorComputer, ELLIPTIC_ANCHOR_KIND, RECTANGULAR_ANCHOR_KIND, DIAMOND_ANCHOR_KIND } from "./anchor";
-import { SConnectableElement } from "./model";
+import { SConnectableElementImpl } from "./model";
 import { PointToPointLine, Diamond, intersection } from "../../utils/geometry";
 import { injectable } from "inversify";
 import { PolylineEdgeRouter } from "./polyline-edge-router";
@@ -28,7 +28,7 @@ export class EllipseAnchor implements IAnchorComputer {
         return PolylineEdgeRouter.KIND + ':' + ELLIPTIC_ANCHOR_KIND;
     }
 
-    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number = 0): Point {
+    getAnchor(connectable: SConnectableElementImpl, refPoint: Point, offset: number = 0): Point {
         const bounds = connectable.bounds;
         const c = Bounds.center(bounds);
         const dx = c.x - refPoint.x;
@@ -50,7 +50,7 @@ export class RectangleAnchor implements IAnchorComputer {
         return PolylineEdgeRouter.KIND + ':' + RECTANGULAR_ANCHOR_KIND;
     }
 
-    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number = 0): Point {
+    getAnchor(connectable: SConnectableElementImpl, refPoint: Point, offset: number = 0): Point {
         const bounds = connectable.bounds;
         const c = Bounds.center(bounds);
         const finder = new NearestPointFinder(c, refPoint);
@@ -119,7 +119,7 @@ export class DiamondAnchor implements IAnchorComputer {
         return PolylineEdgeRouter.KIND + ':' + DIAMOND_ANCHOR_KIND;
     }
 
-    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number): Point {
+    getAnchor(connectable: SConnectableElementImpl, refPoint: Point, offset: number): Point {
         const bounds = connectable.bounds;
         const referenceLine = new PointToPointLine(Bounds.center(bounds), refPoint);
         const closestDiamondSide = new Diamond(bounds).closestSideLine(refPoint);

--- a/packages/sprotty/src/features/routing/polyline-edge-router.ts
+++ b/packages/sprotty/src/features/routing/polyline-edge-router.ts
@@ -16,11 +16,11 @@
 
 import { inject, injectable } from "inversify";
 import { angleBetweenPoints, Bounds, centerOfLine, Point } from "sprotty-protocol/lib/utils/geometry";
-import { SRoutingHandle } from "./model";
+import { SRoutingHandleImpl } from "./model";
 import { ResolvedHandleMove } from "../move/move";
 import { AnchorComputerRegistry } from "./anchor";
 import { AbstractEdgeRouter, LinearRouteOptions } from "./abstract-edge-router";
-import { SRoutableElement } from "./model";
+import { SRoutableElementImpl } from "./model";
 import { RoutedPoint } from "./routing";
 
 export interface PolylineRouteOptions extends LinearRouteOptions {
@@ -39,7 +39,7 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         return PolylineEdgeRouter.KIND;
     }
 
-    protected getOptions(edge: SRoutableElement): PolylineRouteOptions {
+    protected getOptions(edge: SRoutableElementImpl): PolylineRouteOptions {
         return {
             minimalPointDistance: 2,
             removeAngleThreshold: 0.1,
@@ -48,7 +48,7 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         };
     }
 
-    route(edge: SRoutableElement): RoutedPoint[] {
+    route(edge: SRoutableElementImpl): RoutedPoint[] {
         const source = edge.source;
         const target = edge.target;
         if (source === undefined || target === undefined) {
@@ -97,7 +97,7 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
      * Remove routed points that are in edit mode and for which the angle between the preceding and
      * following points falls below a threshold.
      */
-    protected filterEditModeHandles(route: RoutedPoint[], edge: SRoutableElement, options: PolylineRouteOptions): RoutedPoint[] {
+    protected filterEditModeHandles(route: RoutedPoint[], edge: SRoutableElementImpl, options: PolylineRouteOptions): RoutedPoint[] {
         if (edge.children.length === 0)
             return route;
 
@@ -105,8 +105,8 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         while (i < route.length) {
             const curr = route[i];
             if (curr.pointIndex !== undefined) {
-                const handle: SRoutingHandle | undefined = edge.children.find(child =>
-                    child instanceof SRoutingHandle && child.kind === 'junction' && child.pointIndex === curr.pointIndex) as any;
+                const handle: SRoutingHandleImpl | undefined = edge.children.find(child =>
+                    child instanceof SRoutingHandleImpl && child.kind === 'junction' && child.pointIndex === curr.pointIndex) as any;
                 if (handle !== undefined && handle.editMode && i > 0 && i < route.length - 1) {
                     const prev = route[i - 1], next = route[i + 1];
                     const prevDiff: Point = { x: prev.x - curr.x, y: prev.y - curr.y };
@@ -123,7 +123,7 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         return route;
     }
 
-    createRoutingHandles(edge: SRoutableElement): void {
+    createRoutingHandles(edge: SRoutableElementImpl): void {
         const rpCount = edge.routingPoints.length;
         this.addHandle(edge, 'source', 'routing-point', -2);
         this.addHandle(edge, 'line', 'volatile-routing-point', -1);
@@ -134,7 +134,7 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         this.addHandle(edge, 'target', 'routing-point', rpCount);
     }
 
-    getInnerHandlePosition(edge: SRoutableElement, route: RoutedPoint[], handle: SRoutingHandle) {
+    getInnerHandlePosition(edge: SRoutableElementImpl, route: RoutedPoint[], handle: SRoutingHandleImpl) {
         if (handle.kind === 'line') {
             const { start, end } = this.findRouteSegment(edge, route, handle.pointIndex);
             if (start !== undefined && end !== undefined)
@@ -143,7 +143,7 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         return undefined;
     }
 
-    applyInnerHandleMoves(edge: SRoutableElement, moves: ResolvedHandleMove[]) {
+    applyInnerHandleMoves(edge: SRoutableElementImpl, moves: ResolvedHandleMove[]) {
         moves.forEach(move => {
             const handle = move.handle;
             const points = edge.routingPoints;
@@ -154,7 +154,7 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
                 handle.type = 'routing-point';
                 points.splice(index + 1, 0, move.fromPosition || points[Math.max(index, 0)]);
                 edge.children.forEach(child => {
-                    if (child instanceof SRoutingHandle && (child === handle || child.pointIndex > index))
+                    if (child instanceof SRoutingHandleImpl && (child === handle || child.pointIndex > index))
                         child.pointIndex++;
                 });
                 this.addHandle(edge, 'line', 'volatile-routing-point', index);

--- a/packages/sprotty/src/features/routing/views.ts
+++ b/packages/sprotty/src/features/routing/views.ts
@@ -18,7 +18,7 @@ import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { IViewArgs, IView, RenderingContext } from '../../base/views/view';
-import { SRoutableElement, getAbsoluteRouteBounds } from './model';
+import { SRoutableElementImpl, getAbsoluteRouteBounds } from './model';
 
 @injectable()
 export abstract class RoutableView implements IView {
@@ -27,7 +27,7 @@ export abstract class RoutableView implements IView {
      * in your `render` implementation to skip rendering in case the element is not visible.
      * This can greatly enhance performance for large models.
      */
-    isVisible(model: Readonly<SRoutableElement>, route: Point[], context: RenderingContext): boolean {
+    isVisible(model: Readonly<SRoutableElementImpl>, route: Point[], context: RenderingContext): boolean {
         if (context.targetKind === 'hidden') {
             // Don't hide any element for hidden rendering
             return true;
@@ -44,5 +44,5 @@ export abstract class RoutableView implements IView {
             && ab.y + ab.height >= 0;
     }
 
-    abstract render(model: Readonly<SRoutableElement>, context: RenderingContext, args?: IViewArgs): VNode | undefined;
+    abstract render(model: Readonly<SRoutableElementImpl>, context: RenderingContext, args?: IViewArgs): VNode | undefined;
 }

--- a/packages/sprotty/src/features/select/model.ts
+++ b/packages/sprotty/src/features/select/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 
 export const selectFeature = Symbol('selectFeature');
@@ -23,10 +23,10 @@ export interface Selectable extends SModelExtension {
     selected: boolean
 }
 
-export function isSelectable(element: SModelElement): element is SModelElement & Selectable {
+export function isSelectable(element: SModelElementImpl): element is SModelElementImpl & Selectable {
     return element.hasFeature(selectFeature);
 }
 
-export function isSelected(element: SModelElement | undefined): element is SModelElement & Selectable {
+export function isSelected(element: SModelElementImpl | undefined): element is SModelElementImpl & Selectable {
     return element !== undefined && isSelectable(element) && element.selected;
 }

--- a/packages/sprotty/src/features/undo-redo/undo-redo.ts
+++ b/packages/sprotty/src/features/undo-redo/undo-redo.ts
@@ -17,7 +17,7 @@
 import { Action, UndoAction as ProtocolUndoAction, RedoAction as ProtocolRedoAction } from 'sprotty-protocol/lib/actions';
 import { matchesKeystroke } from '../../utils/keyboard';
 import { KeyListener } from '../../base/views/key-tool';
-import { SModelElement } from '../../base/model/smodel';
+import { SModelElementImpl } from '../../base/model/smodel';
 import { isMac } from '../../utils/browser';
 
 /**
@@ -53,7 +53,7 @@ export namespace RedoAction {
 }
 
 export class UndoRedoKeyListener extends KeyListener {
-    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyZ', 'ctrlCmd'))
             return [ProtocolUndoAction.create()];
         if (matchesKeystroke(event, 'KeyZ', 'ctrlCmd', 'shift') || (!isMac() && matchesKeystroke(event, 'KeyY', 'ctrlCmd')))

--- a/packages/sprotty/src/features/update/model-matching.ts
+++ b/packages/sprotty/src/features/update/model-matching.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
-import { SModelRoot, SModelElement, isParent, IModelIndex } from '../../base/model/smodel';
+import { SModelRootImpl, SModelElementImpl, isParent, IModelIndex } from '../../base/model/smodel';
 import { SModelIndex } from 'sprotty-protocol';
 
 export interface Match {
@@ -34,14 +34,14 @@ export function forEachMatch(matchResult: MatchResult, callback: (id: string, ma
 }
 
 export class ModelMatcher {
-    match(left: SModelRootSchema | SModelRoot, right: SModelRootSchema | SModelRoot): MatchResult {
+    match(left: SModelRootSchema | SModelRootImpl, right: SModelRootSchema | SModelRootImpl): MatchResult {
         const result: MatchResult = {};
         this.matchLeft(left, result);
         this.matchRight(right, result);
         return result;
     }
 
-    protected matchLeft(element: SModelElementSchema | SModelElement, result: MatchResult, parentId?: string): void {
+    protected matchLeft(element: SModelElementSchema | SModelElementImpl, result: MatchResult, parentId?: string): void {
         let match = result[element.id];
         if (match !== undefined) {
             match.left = element;
@@ -60,7 +60,7 @@ export class ModelMatcher {
         }
     }
 
-    protected matchRight(element: SModelElementSchema | SModelElement, result: MatchResult, parentId?: string) {
+    protected matchRight(element: SModelElementSchema | SModelElementImpl, result: MatchResult, parentId?: string) {
         let match = result[element.id];
         if (match !== undefined) {
             match.right = element;
@@ -81,7 +81,7 @@ export class ModelMatcher {
 }
 
 export function applyMatches(root: SModelRootSchema, matches: Match[], index?: IModelIndex): void {
-    if (root instanceof SModelRoot) {
+    if (root instanceof SModelRootImpl) {
         index = root.index;
     } else if (index === undefined) {
         index = new SModelIndex();

--- a/packages/sprotty/src/features/viewport/center-fit.ts
+++ b/packages/sprotty/src/features/viewport/center-fit.ts
@@ -18,9 +18,9 @@ import { Action, CenterAction as ProtocolCenterAction, FitToScreenAction as Prot
 import { Viewport } from "sprotty-protocol/lib/model";
 import { Bounds, Dimension } from "sprotty-protocol/lib/utils/geometry";
 import { matchesKeystroke } from "../../utils/keyboard";
-import { SChildElement } from '../../base/model/smodel';
+import { SChildElementImpl } from '../../base/model/smodel';
 import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
-import { SModelElement, SModelRoot } from "../../base/model/smodel";
+import { SModelElementImpl, SModelRootImpl } from "../../base/model/smodel";
 import { KeyListener } from "../../base/views/key-tool";
 import { isBoundsAware } from "../bounds/model";
 import { isSelectable } from "../select/model";
@@ -78,7 +78,7 @@ export abstract class BoundsAwareViewportCommand extends Command {
         super();
     }
 
-    protected initialize(model: SModelRoot) {
+    protected initialize(model: SModelRootImpl) {
         if (isViewport(model)) {
             this.oldViewport = {
                 scroll: model.scroll,
@@ -116,14 +116,14 @@ export abstract class BoundsAwareViewportCommand extends Command {
         }
     }
 
-    protected boundsInViewport(element: SModelElement, bounds: Bounds, viewport: SModelRoot & Viewport): Bounds {
-        if (element instanceof SChildElement && element.parent !== viewport)
+    protected boundsInViewport(element: SModelElementImpl, bounds: Bounds, viewport: SModelRootImpl & Viewport): Bounds {
+        if (element instanceof SChildElementImpl && element.parent !== viewport)
             return this.boundsInViewport(element.parent, element.parent.localToParent(bounds) as Bounds, viewport);
         else
             return bounds;
     }
 
-    protected abstract getNewViewport(bounds: Bounds, model: SModelRoot): Viewport | undefined;
+    protected abstract getNewViewport(bounds: Bounds, model: SModelRootImpl): Viewport | undefined;
 
     protected abstract getElementIds(): string[];
 
@@ -174,7 +174,7 @@ export class CenterCommand extends BoundsAwareViewportCommand {
         return this.action.elementIds;
     }
 
-    getNewViewport(bounds: Bounds, model: SModelRoot): Viewport | undefined {
+    getNewViewport(bounds: Bounds, model: SModelRootImpl): Viewport | undefined {
         if (!Dimension.isValid(model.canvasBounds)) {
             return undefined;
         }
@@ -206,7 +206,7 @@ export class FitToScreenCommand extends BoundsAwareViewportCommand {
         return this.action.elementIds;
     }
 
-    getNewViewport(bounds: Bounds, model: SModelRoot): Viewport | undefined {
+    getNewViewport(bounds: Bounds, model: SModelRootImpl): Viewport | undefined {
         if (!Dimension.isValid(model.canvasBounds)) {
             return undefined;
         }
@@ -233,7 +233,7 @@ export class FitToScreenCommand extends BoundsAwareViewportCommand {
 }
 
 export class CenterKeyboardListener extends KeyListener {
-    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyC', 'ctrlCmd', 'shift'))
             return [ProtocolCenterAction.create([])];
         if (matchesKeystroke(event, 'KeyF', 'ctrlCmd', 'shift'))

--- a/packages/sprotty/src/features/viewport/model.ts
+++ b/packages/sprotty/src/features/viewport/model.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Scrollable, Zoomable, Viewport as ProtocolViewport } from 'sprotty-protocol/lib/model';
-import { SModelElement, SModelRoot } from '../../base/model/smodel';
+import { SModelElementImpl, SModelRootImpl } from '../../base/model/smodel';
 
 export const viewportFeature = Symbol('viewportFeature');
 
@@ -25,8 +25,8 @@ export const viewportFeature = Symbol('viewportFeature');
 export interface Viewport extends Scrollable, Zoomable {
 }
 
-export function isViewport(element: SModelElement): element is SModelRoot & ProtocolViewport {
-    return element instanceof SModelRoot
+export function isViewport(element: SModelElementImpl): element is SModelRootImpl & ProtocolViewport {
+    return element instanceof SModelRootImpl
         && element.hasFeature(viewportFeature)
         && 'zoom' in element
         && 'scroll' in element;

--- a/packages/sprotty/src/features/viewport/scroll.ts
+++ b/packages/sprotty/src/features/viewport/scroll.ts
@@ -16,13 +16,13 @@
 
 import { Action, CenterAction, SetViewportAction } from 'sprotty-protocol/lib/actions';
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SModelElement, SModelRoot } from '../../base/model/smodel';
+import { SModelElementImpl, SModelRootImpl } from '../../base/model/smodel';
 import { MouseListener } from '../../base/views/mouse-tool';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { isViewport } from './model';
 import { isMoveable } from '../move/model';
-import { SRoutingHandle } from '../routing/model';
+import { SRoutingHandleImpl } from '../routing/model';
 import { getModelBounds } from '../projection/model';
 import { hitsMouseEvent } from '../../utils/browser';
 import { Viewport } from 'sprotty-protocol/lib/model';
@@ -37,7 +37,7 @@ export interface Scrollable extends SModelExtension {
 /**
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export function isScrollable(element: SModelElement | Scrollable): element is Scrollable {
+export function isScrollable(element: SModelElementImpl | Scrollable): element is Scrollable {
     return 'scroll' in element;
 }
 
@@ -48,9 +48,9 @@ export class ScrollMouseListener extends MouseListener {
     protected scrollbarMouseDownTimeout: number | undefined;
     protected scrollbarMouseDownDelay = 200;
 
-    override mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override mouseDown(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
         const moveable = findParentByFeature(target, isMoveable);
-        if (moveable === undefined && !(target instanceof SRoutingHandle)) {
+        if (moveable === undefined && !(target instanceof SRoutingHandleImpl)) {
             const viewport = findParentByFeature(target, isViewport);
             if (viewport) {
                 this.lastScrollPosition = { x: event.pageX, y: event.pageY };
@@ -70,7 +70,7 @@ export class ScrollMouseListener extends MouseListener {
         return [];
     }
 
-    override mouseMove(target: SModelElement, event: MouseEvent): Action[] {
+    override mouseMove(target: SModelElementImpl, event: MouseEvent): Action[] {
         if (event.buttons === 0) {
             return this.mouseUp(target, event);
         }
@@ -90,20 +90,20 @@ export class ScrollMouseListener extends MouseListener {
         return [];
     }
 
-    override mouseEnter(target: SModelElement, event: MouseEvent): Action[] {
-        if (target instanceof SModelRoot && event.buttons === 0) {
+    override mouseEnter(target: SModelElementImpl, event: MouseEvent): Action[] {
+        if (target instanceof SModelRootImpl && event.buttons === 0) {
             this.mouseUp(target, event);
         }
         return [];
     }
 
-    override mouseUp(target: SModelElement, event: MouseEvent): Action[] {
+    override mouseUp(target: SModelElementImpl, event: MouseEvent): Action[] {
         this.lastScrollPosition = undefined;
         this.scrollbar = undefined;
         return [];
     }
 
-    override doubleClick(target: SModelElement, event: MouseEvent): Action[] {
+    override doubleClick(target: SModelElementImpl, event: MouseEvent): Action[] {
         const viewport = findParentByFeature(target, isViewport);
         if (viewport) {
             const scrollbar = this.getScrollbar(event);
@@ -124,7 +124,7 @@ export class ScrollMouseListener extends MouseListener {
         return [];
     }
 
-    protected dragCanvas(viewport: SModelRoot & Viewport, event: MouseEvent, lastScrollPosition: Point): Action[] {
+    protected dragCanvas(viewport: SModelRootImpl & Viewport, event: MouseEvent, lastScrollPosition: Point): Action[] {
         const dx = (event.pageX - lastScrollPosition.x) / viewport.zoom;
         const dy = (event.pageY - lastScrollPosition.y) / viewport.zoom;
         const newViewport: Viewport = {
@@ -138,7 +138,7 @@ export class ScrollMouseListener extends MouseListener {
         return [SetViewportAction.create(viewport.id, newViewport, { animate: false })];
     }
 
-    protected moveScrollBar(model: SModelRoot & Viewport, event: MouseEvent, scrollbar: HTMLElement, animate: boolean = false): Action[] {
+    protected moveScrollBar(model: SModelRootImpl & Viewport, event: MouseEvent, scrollbar: HTMLElement, animate: boolean = false): Action[] {
         const modelBounds = getModelBounds(model);
         if (!modelBounds || model.zoom <= 0) {
             return [];

--- a/packages/sprotty/src/features/viewport/viewport-root.ts
+++ b/packages/sprotty/src/features/viewport/viewport-root.ts
@@ -16,7 +16,7 @@
 
 import { SModelRoot as SModelRootSchema, Viewport } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, isBounds, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { SModelRoot, ModelIndexImpl } from '../../base/model/smodel';
+import { SModelRootImpl, ModelIndexImpl } from '../../base/model/smodel';
 import { viewportFeature } from "./model";
 import { exportFeature } from "../export/model";
 import { BoundsAware } from "../bounds/model";
@@ -32,7 +32,7 @@ export interface ViewportRootElementSchema extends SModelRootSchema {
  * Model root element that defines a viewport, so it transforms the coordinate system with
  * a `scroll` translation and a `zoom` scaling.
  */
-export class ViewportRootElement extends SModelRoot implements Viewport, BoundsAware {
+export class ViewportRootElement extends SModelRootImpl implements Viewport, BoundsAware {
     static readonly DEFAULT_FEATURES = [viewportFeature, exportFeature];
 
     scroll: Point = { x: 0, y: 0 };

--- a/packages/sprotty/src/features/viewport/viewport.ts
+++ b/packages/sprotty/src/features/viewport/viewport.ts
@@ -18,7 +18,7 @@ import { injectable, inject } from "inversify";
 import { Action, generateRequestId, RequestAction, ResponseAction, SetViewportAction as ProtocolSetViewPortAction} from "sprotty-protocol/lib/actions";
 import { Viewport } from "sprotty-protocol/lib/model";
 import { Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
-import { SModelElement, SModelRoot } from "../../base/model/smodel";
+import { SModelElementImpl, SModelRootImpl } from "../../base/model/smodel";
 import { MergeableCommand, ICommand, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
 import { Animation } from "../../base/animations/animation";
 import { isViewport } from "./model";
@@ -77,7 +77,7 @@ export namespace ViewportResult {
 export class SetViewportCommand extends MergeableCommand {
     static readonly KIND = ProtocolSetViewPortAction.KIND;
 
-    protected element: SModelElement & Viewport;
+    protected element: SModelElementImpl & Viewport;
     protected oldViewport: Viewport;
     protected newViewport: Viewport;
 
@@ -145,7 +145,7 @@ export class ViewportAnimation extends Animation {
 
     protected zoomFactor: number;
 
-    constructor(protected element: SModelElement & Viewport,
+    constructor(protected element: SModelElementImpl & Viewport,
                 protected oldViewport: Viewport,
                 protected newViewport: Viewport,
                 protected override context: CommandExecutionContext) {
@@ -153,7 +153,7 @@ export class ViewportAnimation extends Animation {
         this.zoomFactor = Math.log(newViewport.zoom / oldViewport.zoom);
     }
 
-    tween(t: number, context: CommandExecutionContext): SModelRoot {
+    tween(t: number, context: CommandExecutionContext): SModelRootImpl {
         this.element.scroll = {
             x: (1 - t) * this.oldViewport.scroll.x + t * this.newViewport.scroll.x,
             y: (1 - t) * this.oldViewport.scroll.y + t * this.newViewport.scroll.y

--- a/packages/sprotty/src/features/viewport/zoom.ts
+++ b/packages/sprotty/src/features/viewport/zoom.ts
@@ -17,7 +17,7 @@
 import { Action, SetViewportAction } from "sprotty-protocol/lib/actions";
 import { Viewport } from "sprotty-protocol/lib/model";
 import { Point } from "sprotty-protocol/lib/utils/geometry";
-import { SModelElement, SModelRoot } from "../../base/model/smodel";
+import { SModelElementImpl, SModelRootImpl } from "../../base/model/smodel";
 import { SModelExtension } from "../../base/model/smodel-extension";
 import { findParentByFeature } from "../../base/model/smodel-utils";
 import { MouseListener } from "../../base/views/mouse-tool";
@@ -34,11 +34,11 @@ export interface Zoomable extends SModelExtension {
 /**
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export function isZoomable(element: SModelElement | Zoomable): element is Zoomable {
+export function isZoomable(element: SModelElementImpl | Zoomable): element is Zoomable {
     return 'zoom' in element;
 }
 
-export function getZoom(label: SModelElement) {
+export function getZoom(label: SModelElementImpl) {
     let zoom = 1;
     const viewport = findParentByFeature(label, isViewport);
     if (viewport) {
@@ -49,7 +49,7 @@ export function getZoom(label: SModelElement) {
 
 export class ZoomMouseListener extends MouseListener {
 
-    override wheel(target: SModelElement, event: WheelEvent): Action[] {
+    override wheel(target: SModelElementImpl, event: WheelEvent): Action[] {
         const viewport = findParentByFeature(target, isViewport);
         if (!viewport) {
             return [];
@@ -72,7 +72,7 @@ export class ZoomMouseListener extends MouseListener {
         };
     }
 
-    protected processZoom(viewport: Viewport, target: SModelElement, event: WheelEvent): Viewport {
+    protected processZoom(viewport: Viewport, target: SModelElementImpl, event: WheelEvent): Viewport {
         const newZoom = this.getZoomFactor(event);
         const viewportOffset = this.getViewportOffset(target.root, event);
         const offsetFactor = 1.0 / (newZoom * viewport.zoom) - 1.0 / viewport.zoom;
@@ -85,7 +85,7 @@ export class ZoomMouseListener extends MouseListener {
         };
     }
 
-    protected getViewportOffset(root: SModelRoot, event: WheelEvent): Point {
+    protected getViewportOffset(root: SModelRootImpl, event: WheelEvent): Point {
         const canvasBounds = root.canvasBounds;
         const windowScroll = getWindowScroll();
         return {

--- a/packages/sprotty/src/features/zorder/zorder.ts
+++ b/packages/sprotty/src/features/zorder/zorder.ts
@@ -17,9 +17,9 @@
 import { injectable, inject } from 'inversify';
 import { Action, BringToFrontAction as ProtocolBringToFrontAction} from 'sprotty-protocol/lib/actions';
 import { TYPES } from '../../base/types';
-import { SModelRoot, SChildElement, SModelElement, SParentElement } from '../../base/model/smodel';
+import { SModelRootImpl, SChildElementImpl, SModelElementImpl, SParentElementImpl } from '../../base/model/smodel';
 import { Command, CommandExecutionContext } from '../../base/commands/command';
-import { SRoutableElement, SConnectableElement } from '../routing/model';
+import { SRoutableElementImpl, SConnectableElementImpl } from '../routing/model';
 
 /**
  * Action to render the selected elements in front of others by manipulating the z-order.
@@ -42,7 +42,7 @@ export namespace BringToFrontAction {
 }
 
 export type ZOrderElement = {
-    element: SChildElement
+    element: SChildElementImpl
     index: number
 };
 
@@ -56,17 +56,17 @@ export class BringToFrontCommand extends Command {
         super();
     }
 
-    execute(context: CommandExecutionContext): SModelRoot {
+    execute(context: CommandExecutionContext): SModelRootImpl {
         const model = context.root;
         this.action.elementIDs.forEach(id => {
             const element = model.index.getById(id);
-            if (element instanceof SRoutableElement) {
+            if (element instanceof SRoutableElementImpl) {
                 if (element.source)
                     this.addToSelection(element.source);
                 if (element.target)
                     this.addToSelection(element.target);
             }
-            if (element instanceof SChildElement) {
+            if (element instanceof SChildElementImpl) {
                 this.addToSelection(element);
             }
             this.includeConnectedEdges(element);
@@ -74,26 +74,26 @@ export class BringToFrontCommand extends Command {
         return this.redo(context);
     }
 
-    protected includeConnectedEdges(element?: SModelElement): void {
-        if (element instanceof SConnectableElement) {
+    protected includeConnectedEdges(element?: SModelElementImpl): void {
+        if (element instanceof SConnectableElementImpl) {
             element.incomingEdges.forEach(edge => this.addToSelection(edge));
             element.outgoingEdges.forEach(edge => this.addToSelection(edge));
         }
-        if (element instanceof SParentElement) {
+        if (element instanceof SParentElementImpl) {
             for (const child of element.children) {
                 this.includeConnectedEdges(child);
             }
         }
     }
 
-    protected addToSelection(element: SChildElement): void {
+    protected addToSelection(element: SChildElementImpl): void {
         this.selected.push({
             element: element,
             index: element.parent.children.indexOf(element)
         });
     }
 
-    undo(context: CommandExecutionContext): SModelRoot {
+    undo(context: CommandExecutionContext): SModelRootImpl {
         for (let i = this.selected.length - 1; i >= 0; i--) {
             const selection = this.selected[i];
             const element = selection.element;
@@ -102,7 +102,7 @@ export class BringToFrontCommand extends Command {
         return context.root;
     }
 
-    redo(context: CommandExecutionContext): SModelRoot {
+    redo(context: CommandExecutionContext): SModelRootImpl {
         for (let i = 0; i < this.selected.length; i++) {
             this.bringToFront(this.selected[i]);
         }

--- a/packages/sprotty/src/graph/sgraph-factory.ts
+++ b/packages/sprotty/src/graph/sgraph-factory.ts
@@ -21,9 +21,9 @@ import {
 } from 'sprotty-protocol/lib/model';
 import { getBasicType } from 'sprotty-protocol/lib/utils/model-utils';
 import { SModelFactory, createFeatureSet } from "../base/model/smodel-factory";
-import { SChildElement, SModelRoot, SParentElement } from "../base/model/smodel";
-import { SCompartment, SEdge, SGraph, SLabel, SNode, SPort } from "./sgraph";
-import { SButton, SButtonSchema } from '../features/button/model';
+import { SChildElementImpl, SModelRootImpl, SParentElementImpl } from "../base/model/smodel";
+import { SCompartmentImpl, SEdgeImpl, SGraphImpl, SLabelImpl, SNodeImpl, SPortImpl } from "./sgraph";
+import { SButtonImpl, SButtonSchema } from '../features/button/model';
 
 /**
  * @deprecated
@@ -33,57 +33,57 @@ import { SButton, SButtonSchema } from '../features/button/model';
 @injectable()
 export class SGraphFactory extends SModelFactory {
 
-    protected readonly defaultGraphFeatures = createFeatureSet(SGraph.DEFAULT_FEATURES);
-    protected readonly defaultNodeFeatures = createFeatureSet(SNode.DEFAULT_FEATURES);
-    protected readonly defaultPortFeatures = createFeatureSet(SPort.DEFAULT_FEATURES);
-    protected readonly defaultEdgeFeatures = createFeatureSet(SEdge.DEFAULT_FEATURES);
-    protected readonly defaultLabelFeatures = createFeatureSet(SLabel.DEFAULT_FEATURES);
-    protected readonly defaultCompartmentFeatures = createFeatureSet(SCompartment.DEFAULT_FEATURES);
-    protected readonly defaultButtonFeatures = createFeatureSet(SButton.DEFAULT_FEATURES);
+    protected readonly defaultGraphFeatures = createFeatureSet(SGraphImpl.DEFAULT_FEATURES);
+    protected readonly defaultNodeFeatures = createFeatureSet(SNodeImpl.DEFAULT_FEATURES);
+    protected readonly defaultPortFeatures = createFeatureSet(SPortImpl.DEFAULT_FEATURES);
+    protected readonly defaultEdgeFeatures = createFeatureSet(SEdgeImpl.DEFAULT_FEATURES);
+    protected readonly defaultLabelFeatures = createFeatureSet(SLabelImpl.DEFAULT_FEATURES);
+    protected readonly defaultCompartmentFeatures = createFeatureSet(SCompartmentImpl.DEFAULT_FEATURES);
+    protected readonly defaultButtonFeatures = createFeatureSet(SButtonImpl.DEFAULT_FEATURES);
 
-    override createElement(schema: SModelElementSchema, parent?: SParentElement): SChildElement {
-        let child: SChildElement;
+    override createElement(schema: SModelElementSchema, parent?: SParentElementImpl): SChildElementImpl {
+        let child: SChildElementImpl;
         if (this.registry.hasKey(schema.type)) {
             const regElement = this.registry.get(schema.type, undefined);
-            if (!(regElement instanceof SChildElement))
+            if (!(regElement instanceof SChildElementImpl))
                 throw new Error(`Element with type ${schema.type} was expected to be an SChildElement.`);
             child = regElement;
         } else if (this.isNodeSchema(schema)) {
-            child = new SNode();
+            child = new SNodeImpl();
             child.features = this.defaultNodeFeatures;
         } else if (this.isPortSchema(schema)) {
-            child = new SPort();
+            child = new SPortImpl();
             child.features = this.defaultPortFeatures;
         } else if (this.isEdgeSchema(schema)) {
-            child = new SEdge();
+            child = new SEdgeImpl();
             child.features = this.defaultEdgeFeatures;
         } else if (this.isLabelSchema(schema)) {
-            child = new SLabel();
+            child = new SLabelImpl();
             child.features = this.defaultLabelFeatures;
         } else if (this.isCompartmentSchema(schema)) {
-            child = new SCompartment();
+            child = new SCompartmentImpl();
             child.features = this.defaultCompartmentFeatures;
         } else if (this.isButtonSchema(schema)) {
-            child = new SButton();
+            child = new SButtonImpl();
             child.features = this.defaultButtonFeatures;
         } else {
-            child = new SChildElement();
+            child = new SChildElementImpl();
         }
         return this.initializeChild(child, schema, parent);
     }
 
-    override createRoot(schema: SModelRootSchema): SModelRoot {
-        let root: SModelRoot;
+    override createRoot(schema: SModelRootSchema): SModelRootImpl {
+        let root: SModelRootImpl;
         if (this.registry.hasKey(schema.type)) {
             const regElement = this.registry.get(schema.type, undefined);
-            if (!(regElement instanceof SModelRoot))
+            if (!(regElement instanceof SModelRootImpl))
                 throw new Error(`Element with type ${schema.type} was expected to be an SModelRoot.`);
             root = regElement;
         } else if (this.isGraphSchema(schema)) {
-            root = new SGraph();
+            root = new SGraphImpl();
             root.features = this.defaultGraphFeatures;
         } else {
-            root = new SModelRoot();
+            root = new SModelRootImpl();
         }
         return this.initializeRoot(root, schema);
     }

--- a/packages/sprotty/src/graph/sgraph.ts
+++ b/packages/sprotty/src/graph/sgraph.ts
@@ -18,10 +18,10 @@ import {
     SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema, SShapeElement as SShapeElementSchema
 } from 'sprotty-protocol/lib/model';
 import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
-import { ModelIndexImpl, SChildElement, SModelElement } from '../base/model/smodel';
+import { ModelIndexImpl, SChildElementImpl, SModelElementImpl } from '../base/model/smodel';
 import {
     Alignable, alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
-    ModelLayoutOptions, SShapeElement
+    ModelLayoutOptions, SShapeElementImpl
 } from '../features/bounds/model';
 import { edgeLayoutFeature, EdgePlacement } from '../features/edge-layout/model';
 import { deletableFeature } from '../features/edit/delete';
@@ -29,7 +29,7 @@ import { editFeature } from '../features/edit/model';
 import { Fadeable, fadeFeature } from '../features/fade/model';
 import { Hoverable, hoverFeedbackFeature, popupFeature } from '../features/hover/model';
 import { moveFeature } from '../features/move/model';
-import { connectableFeature, SConnectableElement, SRoutableElement } from '../features/routing/model';
+import { connectableFeature, SConnectableElementImpl, SRoutableElementImpl } from '../features/routing/model';
 import { Selectable, selectFeature } from '../features/select/model';
 import { ViewportRootElement } from '../features/viewport/viewport-root';
 import { FluentIterable, FluentIterableImpl } from '../utils/iterable';
@@ -50,13 +50,16 @@ export interface SGraphSchema extends SModelRootSchema {
 /**
  * Root element for graph-like models.
  */
-export class SGraph extends ViewportRootElement {
+export class SGraphImpl extends ViewportRootElement {
     layoutOptions?: ModelLayoutOptions;
 
     constructor(index = new SGraphIndex()) {
         super(index);
     }
 }
+
+/** @deprecated Use `SGraphImpl` instead. */
+export const SGraph = SGraphImpl;
 
 /**
  * Serializable schema for SNode.
@@ -76,39 +79,42 @@ export interface SNodeSchema extends SShapeElementSchema {
  * another node via an SEdge. Such a connection can be direct, i.e. the node is the source or target of
  * the edge, or indirect through a port, i.e. it contains an SPort which is the source or target of the edge.
  */
-export class SNode extends SConnectableElement implements Selectable, Fadeable, Hoverable {
+export class SNodeImpl extends SConnectableElementImpl implements Selectable, Fadeable, Hoverable {
     static readonly DEFAULT_FEATURES = [connectableFeature, deletableFeature, selectFeature, boundsFeature,
         moveFeature, layoutContainerFeature, fadeFeature, hoverFeedbackFeature, popupFeature];
 
-    override children: SChildElement[];
+    override children: SChildElementImpl[];
     layout?: string;
     selected: boolean = false;
     hoverFeedback: boolean = false;
     opacity: number = 1;
 
-    override canConnect(routable: SRoutableElement, role: string) {
-        return this.children.find(c => c instanceof SPort) === undefined;
+    override canConnect(routable: SRoutableElementImpl, role: string) {
+        return this.children.find(c => c instanceof SPortImpl) === undefined;
     }
 
-    override get incomingEdges(): FluentIterable<SEdge> {
+    override get incomingEdges(): FluentIterable<SEdgeImpl> {
         const index = this.index;
         if (index instanceof SGraphIndex) {
             return index.getIncomingEdges(this);
         }
-        const allEdges = this.index.all().filter(e => e instanceof SEdge) as FluentIterable<SEdge>;
+        const allEdges = this.index.all().filter(e => e instanceof SEdgeImpl) as FluentIterable<SEdgeImpl>;
         return allEdges.filter(e => e.targetId === this.id);
     }
 
-    override get outgoingEdges(): FluentIterable<SEdge> {
+    override get outgoingEdges(): FluentIterable<SEdgeImpl> {
         const index = this.index;
         if (index instanceof SGraphIndex) {
             return index.getOutgoingEdges(this);
         }
-        const allEdges = this.index.all().filter(e => e instanceof SEdge) as FluentIterable<SEdge>;
+        const allEdges = this.index.all().filter(e => e instanceof SEdgeImpl) as FluentIterable<SEdgeImpl>;
         return allEdges.filter(e => e.sourceId === this.id);
     }
 
 }
+
+/** @deprecated Use `SNodeImpl` instead. */
+export const SNode = SNodeImpl;
 
 /**
  * Serializable schema for SPort.
@@ -125,7 +131,7 @@ export interface SPortSchema extends SShapeElementSchema {
 /**
  * A port is a connection point for edges. It should always be contained in an SNode.
  */
-export class SPort extends SConnectableElement implements Selectable, Fadeable, Hoverable {
+export class SPortImpl extends SConnectableElementImpl implements Selectable, Fadeable, Hoverable {
     static readonly DEFAULT_FEATURES = [connectableFeature, selectFeature, boundsFeature, fadeFeature,
         hoverFeedbackFeature];
 
@@ -133,23 +139,26 @@ export class SPort extends SConnectableElement implements Selectable, Fadeable, 
     hoverFeedback: boolean = false;
     opacity: number = 1;
 
-    override get incomingEdges(): FluentIterable<SEdge> {
+    override get incomingEdges(): FluentIterable<SEdgeImpl> {
         const index = this.index;
         if (index instanceof SGraphIndex) {
             return index.getIncomingEdges(this);
         }
-        return super.incomingEdges.filter(e => e instanceof SEdge) as FluentIterable<SEdge>;
+        return super.incomingEdges.filter(e => e instanceof SEdgeImpl) as FluentIterable<SEdgeImpl>;
     }
 
-    override get outgoingEdges(): FluentIterable<SEdge> {
+    override get outgoingEdges(): FluentIterable<SEdgeImpl> {
         const index = this.index;
         if (index instanceof SGraphIndex) {
             return index.getOutgoingEdges(this);
         }
-        return super.outgoingEdges.filter(e => e instanceof SEdge) as FluentIterable<SEdge>;
+        return super.outgoingEdges.filter(e => e instanceof SEdgeImpl) as FluentIterable<SEdgeImpl>;
     }
 
 }
+
+/** @deprecated Use `SPortImpl` instead. */
+export const SPort = SPortImpl;
 
 /**
  * Serializable schema for SEdge.
@@ -171,7 +180,7 @@ export interface SEdgeSchema extends SModelElementSchema {
  * each of which can be either a node or a port. The source and target elements are referenced via their
  * ids and can be resolved with the index stored in the root element.
  */
-export class SEdge extends SRoutableElement implements Fadeable, Selectable, Hoverable, BoundsAware {
+export class SEdgeImpl extends SRoutableElementImpl implements Fadeable, Selectable, Hoverable, BoundsAware {
     static readonly DEFAULT_FEATURES = [editFeature, deletableFeature, selectFeature, fadeFeature,
         hoverFeedbackFeature];
 
@@ -180,6 +189,9 @@ export class SEdge extends SRoutableElement implements Fadeable, Selectable, Hov
     opacity: number = 1;
 
 }
+
+/** @deprecated Use `SEdgeImpl` instead. */
+export const SEdge = SEdgeImpl;
 
 /**
  * Serializable schema for SLabel.
@@ -194,7 +206,7 @@ export interface SLabelSchema extends SShapeElementSchema {
 /**
  * A label can be attached to a node, edge, or port, and contains some text to be rendered in its view.
  */
-export class SLabel extends SShapeElement implements Selectable, Alignable, Fadeable {
+export class SLabelImpl extends SShapeElementImpl implements Selectable, Alignable, Fadeable {
     static readonly DEFAULT_FEATURES = [boundsFeature, alignFeature, layoutableChildFeature,
         edgeLayoutFeature, fadeFeature];
 
@@ -205,6 +217,9 @@ export class SLabel extends SShapeElement implements Selectable, Alignable, Fade
     edgePlacement?: EdgePlacement;
 
 }
+
+/** @deprecated Use `SLabelImpl` instead. */
+export const SLabel = SLabelImpl;
 
 /**
  * Serializable schema for SCompartment.
@@ -219,28 +234,31 @@ export interface SCompartmentSchema extends SShapeElementSchema {
  * A compartment is used to group multiple child elements such as labels of a node. Usually a `vbox`
  * or `hbox` layout is used to arrange these children.
  */
-export class SCompartment extends SShapeElement implements Fadeable {
+export class SCompartmentImpl extends SShapeElementImpl implements Fadeable {
     static readonly DEFAULT_FEATURES = [boundsFeature, layoutContainerFeature, layoutableChildFeature,
         fadeFeature];
 
-    override children: SChildElement[];
+    override children: SChildElementImpl[];
     layout?: string;
     override layoutOptions?: {[key: string]: string | number | boolean};
     opacity = 1;
 
 }
 
+/** @deprecated Use `SCompartmentImpl` instead. */
+export const SCompartment = SCompartmentImpl;
+
 /**
  * A specialized model index that tracks outgoing and incoming edges.
  */
 export class SGraphIndex extends ModelIndexImpl {
 
-    private outgoing: Map<string, SEdge[]> = new Map;
-    private incoming: Map<string, SEdge[]> = new Map;
+    private outgoing: Map<string, SEdgeImpl[]> = new Map;
+    private incoming: Map<string, SEdgeImpl[]> = new Map;
 
-    override add(element: SModelElement): void {
+    override add(element: SModelElementImpl): void {
         super.add(element);
-        if (element instanceof SEdge) {
+        if (element instanceof SEdgeImpl) {
             // Register the edge in the outgoing map
             if (element.sourceId) {
                 const sourceArr = this.outgoing.get(element.sourceId);
@@ -260,9 +278,9 @@ export class SGraphIndex extends ModelIndexImpl {
         }
     }
 
-    override remove(element: SModelElement): void {
+    override remove(element: SModelElementImpl): void {
         super.remove(element);
-        if (element instanceof SEdge) {
+        if (element instanceof SEdgeImpl) {
             // Remove the edge from the outgoing map
             const sourceArr = this.outgoing.get(element.sourceId);
             if (sourceArr !== undefined) {
@@ -288,7 +306,7 @@ export class SGraphIndex extends ModelIndexImpl {
         }
     }
 
-    override getAttachedElements(element: SModelElement): FluentIterable<SModelElement> {
+    override getAttachedElements(element: SModelElementImpl): FluentIterable<SModelElementImpl> {
         return new FluentIterableImpl(
             () => ({
                 outgoing: this.outgoing.get(element.id),
@@ -319,12 +337,11 @@ export class SGraphIndex extends ModelIndexImpl {
         );
     }
 
-    getIncomingEdges(element: SConnectableElement): FluentIterable<SEdge> {
+    getIncomingEdges(element: SConnectableElementImpl): FluentIterable<SEdgeImpl> {
         return this.incoming.get(element.id) || [];
     }
 
-    getOutgoingEdges(element: SConnectableElement): FluentIterable<SEdge> {
+    getOutgoingEdges(element: SConnectableElementImpl): FluentIterable<SEdgeImpl> {
         return this.outgoing.get(element.id) || [];
     }
 }
-

--- a/packages/sprotty/src/graph/views.tsx
+++ b/packages/sprotty/src/graph/views.tsx
@@ -32,12 +32,12 @@ import {
     isIntersectingRoutedPoint
 } from '../features/edge-intersection/intersection-finder';
 import { isEdgeLayoutable } from '../features/edge-layout/model';
-import { SRoutableElement, SRoutingHandle } from '../features/routing/model';
+import { SRoutableElementImpl, SRoutingHandleImpl } from '../features/routing/model';
 import { EdgeRouterRegistry, RoutedPoint } from '../features/routing/routing';
 import { RoutableView } from '../features/routing/views';
 import { svg } from '../lib/jsx';
 import { PointToPointLine } from '../utils/geometry';
-import { SCompartment, SEdge, SGraph, SLabel } from "./sgraph";
+import { SCompartmentImpl, SEdgeImpl, SGraphImpl, SLabelImpl } from "./sgraph";
 
 /**
  * IView component that turns an SGraph element and its children into a tree of virtual DOM elements.
@@ -47,7 +47,7 @@ export class SGraphView implements IView {
 
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
 
-    render(model: Readonly<SGraph>, context: RenderingContext): VNode {
+    render(model: Readonly<SGraphImpl>, context: RenderingContext): VNode {
         const edgeRouting = this.edgeRouterRegistry.routeAllChildren(model);
         const transform = `scale(${model.zoom}) translate(${-model.scroll.x},${-model.scroll.y})`;
         return <svg class-sprotty-graph={true}>
@@ -64,7 +64,7 @@ export class PolylineEdgeView extends RoutableView {
 
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
 
-    render(edge: Readonly<SEdge>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
+    render(edge: Readonly<SEdgeImpl>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
         const route = this.edgeRouterRegistry.route(edge, args);
         if (route.length === 0) {
             return this.renderDanglingEdge("Cannot compute route", edge, context);
@@ -85,7 +85,7 @@ export class PolylineEdgeView extends RoutableView {
         </g>;
     }
 
-    protected renderLine(edge: SEdge, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
+    protected renderLine(edge: SEdgeImpl, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
         const firstPoint = segments[0];
         let path = `M ${firstPoint.x},${firstPoint.y}`;
         for (let i = 1; i < segments.length; i++) {
@@ -95,12 +95,12 @@ export class PolylineEdgeView extends RoutableView {
         return <path d={path} />;
     }
 
-    protected renderAdditionals(edge: SEdge, segments: Point[], context: RenderingContext): VNode[] {
+    protected renderAdditionals(edge: SEdgeImpl, segments: Point[], context: RenderingContext): VNode[] {
         // here we need to render the control points?
         return [];
     }
 
-    protected renderDanglingEdge(message: string, edge: SEdge, context: RenderingContext): VNode {
+    protected renderDanglingEdge(message: string, edge: SEdgeImpl, context: RenderingContext): VNode {
         return <text class-sprotty-edge-dangling={true} title={message}>?</text>;
     }
 }
@@ -125,7 +125,7 @@ export class JumpingPolylineEdgeView extends PolylineEdgeView {
     protected skipOffsetBefore = 3;
     protected skipOffsetAfter = 2;
 
-    protected override renderLine(edge: SEdge, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
+    protected override renderLine(edge: SEdgeImpl, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
         let path = '';
         for (let i = 0; i < segments.length; i++) {
             const p = segments[i];
@@ -145,7 +145,7 @@ export class JumpingPolylineEdgeView extends PolylineEdgeView {
     /**
      * Returns a path that takes the intersections into account by drawing a line jump or a gap for intersections on that path.
      */
-    protected intersectionPath(edge: SEdge, segments: Point[], intersectingPoint: IntersectingRoutedPoint, args?: IViewArgs): string {
+    protected intersectionPath(edge: SEdgeImpl, segments: Point[], intersectingPoint: IntersectingRoutedPoint, args?: IViewArgs): string {
         if (intersectingPoint.intersections.length < 1) {
             return '';
         }
@@ -217,16 +217,16 @@ export class JumpingPolylineEdgeView extends PolylineEdgeView {
         return !this.shouldDrawLineJumpOnIntersection(currentLineSegment, otherLineSegment);
     }
 
-    protected getLineSegment(edge: SRoutableElement, intersection: Intersection, args?: IViewArgs, segments?: Point[]): PointToPointLine {
+    protected getLineSegment(edge: SRoutableElementImpl, intersection: Intersection, args?: IViewArgs, segments?: Point[]): PointToPointLine {
         const route = segments ? segments : this.edgeRouterRegistry.route(edge, args);
         const index = intersection.routable1 === edge.id ? intersection.segmentIndex1 : intersection.segmentIndex2;
         return new PointToPointLine(route[index], route[index + 1]);
     }
 
-    protected getOtherLineSegment(currentEdge: SEdge, intersection: Intersection, args?: IViewArgs): PointToPointLine | undefined {
+    protected getOtherLineSegment(currentEdge: SEdgeImpl, intersection: Intersection, args?: IViewArgs): PointToPointLine | undefined {
         const otherEdgeId = intersection.routable1 === currentEdge.id ? intersection.routable2 : intersection.routable1;
         const otherEdge = currentEdge.index.getById(otherEdgeId);
-        if (!(otherEdge instanceof SRoutableElement)) {
+        if (!(otherEdge instanceof SRoutableElementImpl)) {
             return undefined;
         }
         return this.getLineSegment(otherEdge, intersection, args);
@@ -295,7 +295,7 @@ export class BezierCurveEdgeView extends RoutableView {
 
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
 
-    render(edge: Readonly<SEdge>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
+    render(edge: Readonly<SEdgeImpl>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
         const route = this.edgeRouterRegistry.route(edge, args);
         if (route.length === 0) {
             return this.renderDanglingEdge("Cannot compute route", edge, context);
@@ -316,7 +316,7 @@ export class BezierCurveEdgeView extends RoutableView {
         </g>;
     }
 
-    protected renderLine(edge: SEdge, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
+    protected renderLine(edge: SEdgeImpl, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
         /**
          * Example for two splines:
          * SVG:
@@ -359,11 +359,11 @@ export class BezierCurveEdgeView extends RoutableView {
         return ` S${c.x},${c.y} ${p.x},${p.y}`;
     }
 
-    protected renderAdditionals(edge: SEdge, segments: Point[], context: RenderingContext): VNode[] {
+    protected renderAdditionals(edge: SEdgeImpl, segments: Point[], context: RenderingContext): VNode[] {
         return [];
     }
 
-    protected renderDanglingEdge(message: string, edge: SEdge, context: RenderingContext): VNode {
+    protected renderDanglingEdge(message: string, edge: SEdgeImpl, context: RenderingContext): VNode {
         return <text class-sprotty-edge-dangling={true} title={message}>?</text>;
     }
 }
@@ -375,9 +375,9 @@ export class SRoutingHandleView implements IView {
 
     minimalPointDistance: number = 10;
 
-    render(handle: Readonly<SRoutingHandle>, context: RenderingContext, args?: { route?: RoutedPoint[] }): VNode {
+    render(handle: Readonly<SRoutingHandleImpl>, context: RenderingContext, args?: { route?: RoutedPoint[] }): VNode {
         if (args && args.route) {
-            if (handle.parent instanceof SRoutableElement) {
+            if (handle.parent instanceof SRoutableElementImpl) {
                 const router = this.edgeRouterRegistry.get(handle.parent.routerKind);
                 const theRoute = args.route === undefined ? this.edgeRouterRegistry.route(handle.parent, args) : args.route;
                 const position = router.getHandlePosition(handle.parent, theRoute, handle);
@@ -401,7 +401,7 @@ export class SRoutingHandleView implements IView {
 
 @injectable()
 export class SLabelView extends ShapeView {
-    render(label: Readonly<SLabel>, context: RenderingContext): VNode | undefined {
+    render(label: Readonly<SLabelImpl>, context: RenderingContext): VNode | undefined {
         if (!isEdgeLayoutable(label) && !this.isVisible(label, context)) {
             return undefined;
         }
@@ -416,7 +416,7 @@ export class SLabelView extends ShapeView {
 
 @injectable()
 export class SCompartmentView implements IView {
-    render(compartment: Readonly<SCompartment>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
+    render(compartment: Readonly<SCompartmentImpl>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
         const translate = `translate(${compartment.bounds.x}, ${compartment.bounds.y})`;
         const vnode = <g transform={translate} class-sprotty-comp="{true}">
             {context.renderChildren(compartment)}
@@ -431,10 +431,10 @@ export class SCompartmentView implements IView {
 @injectable()
 export class SBezierCreateHandleView extends SRoutingHandleView {
 
-    override render(handle: Readonly<SRoutingHandle>, context: RenderingContext, args?: { route?: RoutedPoint[] }): VNode {
+    override render(handle: Readonly<SRoutingHandleImpl>, context: RenderingContext, args?: { route?: RoutedPoint[] }): VNode {
         if (args) {
             const theRoute = args.route;
-            if (theRoute && handle.parent instanceof SRoutableElement) {
+            if (theRoute && handle.parent instanceof SRoutableElementImpl) {
                 const router = this.edgeRouterRegistry.get(handle.parent.routerKind);
                 const position = router.getHandlePosition(handle.parent, theRoute, handle);
                 if (position !== undefined) {
@@ -463,10 +463,10 @@ export class SBezierCreateHandleView extends SRoutingHandleView {
 @injectable()
 export class SBezierControlHandleView extends SRoutingHandleView {
 
-    override render(handle: Readonly<SRoutingHandle>, context: RenderingContext, args?: { route?: RoutedPoint[] }): VNode {
+    override render(handle: Readonly<SRoutingHandleImpl>, context: RenderingContext, args?: { route?: RoutedPoint[] }): VNode {
         if (args) {
             const theRoute = args.route;
-            if (theRoute && handle.parent instanceof SRoutableElement) {
+            if (theRoute && handle.parent instanceof SRoutableElementImpl) {
                 const router = this.edgeRouterRegistry.get(handle.parent.routerKind);
                 const position = router.getHandlePosition(handle.parent, theRoute, handle) as any;
                 if (position !== undefined) {

--- a/packages/sprotty/src/lib/generic-views.tsx
+++ b/packages/sprotty/src/lib/generic-views.tsx
@@ -22,12 +22,12 @@ import { VNode } from "snabbdom";
 import { IView, RenderingContext } from "../base/views/view";
 import { setNamespace, setAttr } from "../base/views/vnode-utils";
 import { ShapeView } from "../features/bounds/views";
-import { ForeignObjectElement, PreRenderedElement, ShapedPreRenderedElement } from "./model";
+import { ForeignObjectElementImpl, PreRenderedElementImpl, ShapedPreRenderedElementImpl } from "./model";
 
 @injectable()
 export class PreRenderedView extends ShapeView {
-    render(model: Readonly<PreRenderedElement>, context: RenderingContext): VNode | undefined {
-        if (model instanceof ShapedPreRenderedElement && !this.isVisible(model, context)) {
+    render(model: Readonly<PreRenderedElementImpl>, context: RenderingContext): VNode | undefined {
+        if (model instanceof ShapedPreRenderedElementImpl && !this.isVisible(model, context)) {
             return undefined;
         }
         const node = virtualize(model.code);
@@ -48,7 +48,7 @@ export class PreRenderedView extends ShapeView {
  */
 @injectable()
 export class ForeignObjectView implements IView {
-    render(model: ForeignObjectElement, context: RenderingContext): VNode | undefined{
+    render(model: ForeignObjectElementImpl, context: RenderingContext): VNode | undefined{
         const foreignObjectContents = virtualize(model.code);
         if (foreignObjectContents === null) return undefined;
         const node = <g>

--- a/packages/sprotty/src/lib/html-views.tsx
+++ b/packages/sprotty/src/lib/html-views.tsx
@@ -21,14 +21,14 @@ import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { IView, RenderingContext } from '../base/views/view';
 import { setClass } from '../base/views/vnode-utils';
-import { HtmlRoot } from './model';
+import { HtmlRootImpl } from './model';
 
 /**
  * View for `HtmlRoot` elements. Typically this is used in hover popup boxes.
  */
 @injectable()
 export class HtmlRootView implements IView {
-    render(model: HtmlRoot, context: RenderingContext): VNode {
+    render(model: HtmlRootImpl, context: RenderingContext): VNode {
         const root = <div>
             { context.renderChildren(model) }
         </div>;

--- a/packages/sprotty/src/lib/model.ts
+++ b/packages/sprotty/src/lib/model.ts
@@ -16,17 +16,17 @@
 
 import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
-import { SModelRoot, SChildElement } from "../base/model/smodel";
+import { SModelRootImpl, SChildElementImpl } from "../base/model/smodel";
 import { BoundsAware, boundsFeature, Alignable, alignFeature, isBoundsAware } from "../features/bounds/model";
 import { Locateable, moveFeature } from "../features/move/model";
 import { Selectable, selectFeature } from "../features/select/model";
-import { SNode, SPort } from '../graph/sgraph';
+import { SNodeImpl, SPortImpl } from '../graph/sgraph';
 import { RECTANGULAR_ANCHOR_KIND, DIAMOND_ANCHOR_KIND, ELLIPTIC_ANCHOR_KIND } from "../features/routing/anchor";
 
 /**
  * A node that is represented by a circle.
  */
-export class CircularNode extends SNode {
+export class CircularNode extends SNodeImpl {
     override get anchorKind() {
         return ELLIPTIC_ANCHOR_KIND;
     }
@@ -35,7 +35,7 @@ export class CircularNode extends SNode {
 /**
  * A node that is represented by a rectangle.
  */
-export class RectangularNode extends SNode {
+export class RectangularNode extends SNodeImpl {
     override get anchorKind() {
         return RECTANGULAR_ANCHOR_KIND;
     }
@@ -44,7 +44,7 @@ export class RectangularNode extends SNode {
 /**
  * A node that is represented by a diamond.
  */
-export class DiamondNode extends SNode {
+export class DiamondNode extends SNodeImpl {
     override get anchorKind() {
         return DIAMOND_ANCHOR_KIND;
     }
@@ -53,7 +53,7 @@ export class DiamondNode extends SNode {
 /**
  * A port that is represented by a circle.
  */
-export class CircularPort extends SPort {
+export class CircularPort extends SPortImpl {
     override get anchorKind() {
         return ELLIPTIC_ANCHOR_KIND;
     }
@@ -62,7 +62,7 @@ export class CircularPort extends SPort {
 /**
  * A port that is represented by a rectangle.
  */
-export class RectangularPort extends SPort {
+export class RectangularPort extends SPortImpl {
     override get anchorKind() {
         return RECTANGULAR_ANCHOR_KIND;
     }
@@ -80,9 +80,12 @@ export interface HtmlRootSchema extends SModelRootSchema {
 /**
  * Root model element class for HTML content. Usually this is rendered with a `div` DOM element.
  */
-export class HtmlRoot extends SModelRoot {
+export class HtmlRootImpl extends SModelRootImpl {
     classes: string[] = [];
 }
+
+/** @deprecated Use `HtmlRootImpl` instead. */
+export const HtmlRoot = HtmlRootImpl;
 
 /**
  * Serializable schema for PreRenderedElement.
@@ -97,9 +100,12 @@ export interface PreRenderedElementSchema extends SModelElementSchema {
  * Pre-rendered elements contain HTML or SVG code to be transferred to the DOM. This can be useful to
  * render complex figures or to compute the view on the server instead of the client code.
  */
-export class PreRenderedElement extends SChildElement {
+export class PreRenderedElementImpl extends SChildElementImpl {
     code: string;
 }
+
+/** @deprecated Use `PreRenderedElementImpl` instead. */
+export const PreRenderedElement = PreRenderedElementImpl;
 
 /**
  * Serializable schema for ShapedPreRenderedElement.
@@ -114,7 +120,7 @@ export interface ShapedPreRenderedElementSchema extends PreRenderedElementSchema
 /**
  * Same as PreRenderedElement, but with a position and a size.
  */
-export class ShapedPreRenderedElement extends PreRenderedElement implements BoundsAware, Locateable, Selectable, Alignable {
+export class ShapedPreRenderedElementImpl extends PreRenderedElementImpl implements BoundsAware, Locateable, Selectable, Alignable {
     static readonly DEFAULT_FEATURES = [moveFeature, boundsFeature, selectFeature, alignFeature];
 
     position: Point = Point.ORIGIN;
@@ -144,6 +150,9 @@ export class ShapedPreRenderedElement extends PreRenderedElement implements Boun
 
 }
 
+/** @deprecated Use `ShapedPreRenderedElementImpl` instead. */
+export const ShapedPreRenderedElement = ShapedPreRenderedElementImpl;
+
 /**
  * A `foreignObject` element to be transferred to the DOM within the SVG.
  *
@@ -155,7 +164,7 @@ export class ShapedPreRenderedElement extends PreRenderedElement implements Boun
  * its parent to fill the entire available room. Thus, this element requires specified bounds itself
  * or bounds to be available for its parent.
  */
-export class ForeignObjectElement extends ShapedPreRenderedElement {
+export class ForeignObjectElementImpl extends ShapedPreRenderedElementImpl {
     namespace: string;
     override get bounds(): Bounds {
         if (Dimension.isValid(this.size)) {
@@ -176,6 +185,9 @@ export class ForeignObjectElement extends ShapedPreRenderedElement {
         return Bounds.EMPTY;
     }
 }
+
+/** @deprecated Use `ForeignObjectElementImpl` instead. */
+export const ForeignObjectElement = ForeignObjectElementImpl;
 
 /**
  * Serializable schema for ForeignObjectElement.

--- a/packages/sprotty/src/lib/svg-views.tsx
+++ b/packages/sprotty/src/lib/svg-views.tsx
@@ -20,14 +20,14 @@ import { svg } from './jsx';
 import { VNode } from "snabbdom";
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { IView, IViewArgs, RenderingContext } from "../base/views/view";
-import { SNode, SPort } from "../graph/sgraph";
+import { SNodeImpl, SPortImpl } from "../graph/sgraph";
 import { ViewportRootElement } from "../features/viewport/viewport-root";
-import { SShapeElement } from '../features/bounds/model';
+import { SShapeElementImpl } from '../features/bounds/model';
 import { ShapeView } from '../features/bounds/views';
 import { Hoverable } from '../features/hover/model';
 import { Selectable } from '../features/select/model';
 import { Diamond } from '../utils/geometry';
-import { SModelElement } from '../base/model/smodel';
+import { SModelElementImpl } from '../base/model/smodel';
 import { injectable } from 'inversify';
 
 @injectable()
@@ -44,20 +44,20 @@ export class SvgViewportView implements IView {
 
 @injectable()
 export class CircularNodeView extends ShapeView {
-    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
+    render(node: Readonly<SShapeElementImpl & Hoverable & Selectable>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
         if (!this.isVisible(node, context)) {
             return undefined;
         }
         const radius = this.getRadius(node);
         return <g>
-            <circle class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
+            <circle class-sprotty-node={node instanceof SNodeImpl} class-sprotty-port={node instanceof SPortImpl}
                     class-mouseover={node.hoverFeedback} class-selected={node.selected}
                     r={radius} cx={radius} cy={radius}></circle>
             {context.renderChildren(node)}
         </g>;
     }
 
-    protected getRadius(node: SShapeElement): number {
+    protected getRadius(node: SShapeElementImpl): number {
         const d = Math.min(node.size.width, node.size.height);
         return d > 0 ? d / 2 : 0;
     }
@@ -65,12 +65,12 @@ export class CircularNodeView extends ShapeView {
 
 @injectable()
 export class RectangularNodeView extends ShapeView {
-    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
+    render(node: Readonly<SShapeElementImpl & Hoverable & Selectable>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
         if (!this.isVisible(node, context)) {
             return undefined;
         }
         return <g>
-            <rect class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
+            <rect class-sprotty-node={node instanceof SNodeImpl} class-sprotty-port={node instanceof SPortImpl}
                   class-mouseover={node.hoverFeedback} class-selected={node.selected}
                   x="0" y="0" width={Math.max(node.size.width, 0)} height={Math.max(node.size.height, 0)}></rect>
             {context.renderChildren(node)}
@@ -80,14 +80,14 @@ export class RectangularNodeView extends ShapeView {
 
 @injectable()
 export class DiamondNodeView extends ShapeView {
-    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
+    render(node: Readonly<SShapeElementImpl & Hoverable & Selectable>, context: RenderingContext, args?: IViewArgs): VNode | undefined {
         if (!this.isVisible(node, context)) {
             return undefined;
         }
         const diamond = new Diamond({ height: Math.max(node.size.height, 0), width: Math.max(node.size.width, 0), x: 0, y: 0 });
         const points = `${svgStr(diamond.topPoint)} ${svgStr(diamond.rightPoint)} ${svgStr(diamond.bottomPoint)} ${svgStr(diamond.leftPoint)}`;
         return <g>
-            <polygon class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
+            <polygon class-sprotty-node={node instanceof SNodeImpl} class-sprotty-port={node instanceof SPortImpl}
                   class-mouseover={node.hoverFeedback} class-selected={node.selected}
                   points={points} />
             {context.renderChildren(node)}
@@ -101,7 +101,7 @@ function svgStr(point: Point) {
 
 @injectable()
 export class EmptyGroupView implements IView {
-    render(model: Readonly<SModelElement>, context: RenderingContext): VNode {
+    render(model: Readonly<SModelElementImpl>, context: RenderingContext): VNode {
         return <g></g>;
     }
 }

--- a/packages/sprotty/src/model-source/commit-model.ts
+++ b/packages/sprotty/src/model-source/commit-model.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from "inversify";
 import { Action } from "sprotty-protocol/lib/actions";
 import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { CommandExecutionContext, CommandReturn, SystemCommand } from "../base/commands/command";
-import { SModelRoot } from "../base/model/smodel";
+import { SModelRootImpl } from "../base/model/smodel";
 import { TYPES } from "../base/types";
 import { ModelSource } from "./model-source";
 
@@ -61,7 +61,7 @@ export class CommitModelCommand extends SystemCommand {
         return this.doCommit(this.newModel, context.root, true);
     }
 
-    protected doCommit(model: SModelRootSchema, result: SModelRoot, doSetOriginal: boolean): CommandReturn {
+    protected doCommit(model: SModelRootSchema, result: SModelRootImpl, doSetOriginal: boolean): CommandReturn {
         const commitResult = this.modelSource.commitModel(model);
         if (commitResult instanceof Promise) {
             return commitResult.then(originalModel => {


### PR DESCRIPTION
This has been discussed before for quite some time, now I'd like to make a step forward in preparation of #231: The _internal model_ classes like `SModelElement`, `SNode` etc. have the same names as the _external model_ interfaces defined in `sprotty-protocol`. This is a source of confusion for users.

Historically, the external model interfaces had a `Schema` suffix to disambiguate, but I removed that during the move to the `sprotty-protocol` package. I now regard the external model as the primary interface. The internal model is used primarily at the diagram configuration with InversifyJS (`configureModelElement`) and as arguments to custom services such as views.

I propose to use the `Impl` suffix for internal model classes and deprecate the previous symbols. I would release v0.14.0 with this change (and maybe others) so users can migrate gracefully with the deprecation notices. Then I'd remove all deprecated code when we shift to v1.0.0.