### PR TITLE
Bump TypeScript 5 and Inversify 6

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -20,7 +20,7 @@
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.1",
     "ts-loader": "^9.4.2",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1"
   },

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -40,7 +40,7 @@ const config = {
 
     plugins: [
         new CircularDependencyPlugin({
-            exclude: /node_modules\/inversify/,
+            exclude: /inversify/,
             failOnError: true
         })
     ],

--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -42,7 +42,7 @@
     "sprotty-protocol": "^0.13.0"
   },
   "optionalDependencies": {
-    "inversify": "^5.1.1"
+    "inversify": "~6.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",
@@ -60,7 +60,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.8",
     "ts-mocha": "^10.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",

--- a/packages/sprotty-protocol/package.json
+++ b/packages/sprotty-protocol/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.8",
     "ts-mocha": "^10.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -51,10 +51,12 @@
     "url": "https://github.com/eclipse/sprotty",
     "directory": "packages/sprotty"
   },
+  "peerDependencies": {
+    "inversify": "~6.0.1"
+  },
   "dependencies": {
     "autocompleter": "^7.0.1",
     "file-saver": "^2.0.5",
-    "inversify": "^5.1.1",
     "snabbdom": "^3.5.1",
     "sprotty-protocol": "^0.13.0",
     "tinyqueue": "^2.0.3"
@@ -78,7 +80,7 @@
     "semver": "^7.3.8",
     "snabbdom-to-html": "^7.1.0",
     "ts-mocha": "^10.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3310,10 +3310,10 @@ interpret@^3.1.1:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
   integrity sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==
 
-inversify@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.1.1.tgz#6fbd668c591337404e005a1946bfe0d802c08730"
-  integrity sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ==
+inversify@~6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.0.1.tgz#b20d35425d5d8c5cd156120237aad0008d969f02"
+  integrity sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==
 
 ip@^2.0.0:
   version "2.0.0"
@@ -6094,10 +6094,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@~4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@~5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
When upgrading to TypeSript 5 and using `@inject` in a constructor the following error is raised:
```
Argument of type 'undefined' is not assignable to parameter of type 'string'
```
Upgrading to inversify 6 resolves the issue.

See this comment: https://github.com/microsoft/TypeScript/issues/52435#issuecomment-1405483291 and the following.

Related: https://github.com/eclipse-theia/theia/pull/12425

Inversify is now a `peerDependency` addressing: https://github.com/eclipse-sprotty/sprotty/issues/296
