### PR TITLE
Consider compartments in ELK layout, add pre/postprocessors

### DIFF
--- a/examples/random-graph-distributed/random-graph.html
+++ b/examples/random-graph-distributed/random-graph.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Sprotty Mindmap Example</title>
+    <title>Sprotty Random Graph Example</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="css/page.css">
     <!-- support Microsoft browsers -->

--- a/examples/random-graph/random-graph.html
+++ b/examples/random-graph/random-graph.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Sprotty Mindmap Example</title>
+    <title>Sprotty Random Graph Example</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="css/page.css">
     <!-- support Microsoft browsers -->

--- a/packages/sprotty-elk/src/elk-layout.spec.ts
+++ b/packages/sprotty-elk/src/elk-layout.spec.ts
@@ -19,15 +19,18 @@ import 'mocha';
 import { expect } from 'chai';
 import { Container } from 'inversify';
 import ElkConstructor from 'elkjs/lib/elk.bundled';
-import { SEdge, SGraph, SNode, SPort } from 'sprotty-protocol/lib/model';
-import { ElkFactory, ElkLayoutEngine, elkLayoutModule } from './inversify';
+import { SCompartment, SEdge, SGraph, SNode, SPort } from 'sprotty-protocol/lib/model';
+import { ElkFactory, ElkLayoutEngine, ILayoutPreprocessor, elkLayoutModule } from './inversify';
 
 describe('ElkLayoutEngine', () => {
-    const container = new Container();
-    container.load(elkLayoutModule);
-    container.bind(ElkFactory).toConstantValue(() => new ElkConstructor({
-        algorithms: ['layered']
-    }));
+    function createContainer() {
+        const container = new Container();
+        container.load(elkLayoutModule);
+        container.bind(ElkFactory).toConstantValue(() => new ElkConstructor({
+            algorithms: ['layered']
+        }));
+        return container;
+    }
 
     it('arranges a very simple graph', async () => {
         const graph: SGraph = {
@@ -53,6 +56,7 @@ describe('ElkLayoutEngine', () => {
             ]
         };
 
+        const container = createContainer();
         const elkEngine = container.get(ElkLayoutEngine);
         const result = await elkEngine.layout(graph);
 
@@ -122,6 +126,7 @@ describe('ElkLayoutEngine', () => {
             ]
         };
 
+        const container = createContainer();
         const elkEngine = container.get(ElkLayoutEngine);
         const result = await elkEngine.layout(graph);
 
@@ -169,5 +174,88 @@ describe('ElkLayoutEngine', () => {
                 }
             ]
         });
+    });
+
+    it('considers compartments for padding', async () => {
+        const graph: SGraph = {
+            type: 'graph',
+            id: 'graph',
+            children: [
+                // Node with a child node in a compartment
+                <SNode> {
+                    type: 'node',
+                    id: 'node0',
+                    size: { width: 10, height: 10 },
+                    layout: 'test',
+                    children: [
+                        <SCompartment> {
+                            type: 'compartment',
+                            id: 'compartment0',
+                            position: { x: 5, y: 5 },
+                            size: { width: 0, height: 0 },
+                            children: [
+                                <SNode> {
+                                    type: 'node',
+                                    id: 'node1',
+                                    size: { width: 10, height: 10 }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                // Node with a child node in two nested compartments
+                <SNode> {
+                    type: 'node',
+                    id: 'node2',
+                    size: { width: 27, height: 25 },
+                    layout: 'test',
+                    children: [
+                        <SCompartment> {
+                            type: 'compartment',
+                            id: 'compartment1',
+                            position: { x: 2, y: 1 },
+                            size: { width: 21, height: 21 },
+                            layout: 'test',
+                            children: [
+                                <SCompartment> {
+                                    type: 'compartment',
+                                    id: 'compartment2',
+                                    position: { x: 10, y: 10 },
+                                    size: { width: 1, height: 1 },
+                                    children: [
+                                        <SNode> {
+                                            type: 'node',
+                                            id: 'node3',
+                                            size: { width: 10, height: 10 }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Capture the computed padding settings with a preprocessor
+        let padding1: string | undefined;
+        let padding2: string | undefined;
+        const preprocessor: ILayoutPreprocessor = {
+            preprocess: (elkNode) => {
+                padding1 = elkNode.children![0].layoutOptions!['org.eclipse.elk.padding'];
+                padding2 = elkNode.children![1].layoutOptions!['org.eclipse.elk.padding'];
+            }
+        };
+        const container = createContainer();
+        container.bind(ILayoutPreprocessor).toConstantValue(preprocessor);
+        const elkEngine = container.get(ElkLayoutEngine);
+        const result = await elkEngine.layout(graph);
+
+        expect(padding1).to.equal('[top=5,left=5,bottom=5,right=5]');
+        expect(padding2).to.equal('[top=11,left=12,bottom=13,right=14]');
+        expect((result as any).children[0].size.width).to.equal(20);
+        expect((result as any).children[0].size.height).to.equal(20);
+        expect((result as any).children[1].size.width).to.equal(36);
+        expect((result as any).children[1].size.height).to.equal(34);
     });
 });

--- a/packages/sprotty-elk/src/inversify.ts
+++ b/packages/sprotty-elk/src/inversify.ts
@@ -18,7 +18,8 @@ import { ContainerModule, injectable } from 'inversify';
 import {
     ElkLayoutEngine as ElkLayoutEnginePlain, DefaultElementFilter as DefaultElementFilterPlain,
     DefaultLayoutConfigurator as DefaultLayoutConfiguratorPlain, ElkFactory as ElkFactoryPlain,
-    IElementFilter as IElementFilterPlain, ILayoutConfigurator as ILayoutConfiguratorPlain
+    IElementFilter as IElementFilterPlain, ILayoutConfigurator as ILayoutConfiguratorPlain,
+    ILayoutPreprocessor as ILayoutPreprocessorPlain, ILayoutPostprocessor as ILayoutPostprocessorPlain
 } from './elk-layout';
 
 export const ElkLayoutEngine: typeof ElkLayoutEnginePlain = injectable()(ElkLayoutEnginePlain);
@@ -33,6 +34,12 @@ export const DefaultElementFilter: typeof DefaultElementFilterPlain = injectable
 export type ILayoutConfigurator = ILayoutConfiguratorPlain;
 export const ILayoutConfigurator = Symbol('ILayoutConfigurator');
 export const DefaultLayoutConfigurator: typeof DefaultLayoutConfiguratorPlain = injectable()(DefaultLayoutConfiguratorPlain);
+
+export type ILayoutPreprocessor = ILayoutPreprocessorPlain;
+export const ILayoutPreprocessor = Symbol('ILayoutPreprocessor');
+
+export type ILayoutPostprocessor = ILayoutPostprocessorPlain;
+export const ILayoutPostprocessor = Symbol('ILayoutPostprocessor');
 
 /**
  * This dependency injection module adds the default bindings for the frontend integration of ELK.
@@ -55,7 +62,11 @@ export const elkLayoutModule = new ContainerModule(bind => {
         const elkFactory = context.container.get<ElkFactory>(ElkFactory);
         const elementFilter = context.container.get<IElementFilter>(IElementFilter);
         const layoutConfigurator = context.container.get<ILayoutConfigurator>(ILayoutConfigurator);
-        return new ElkLayoutEngine(elkFactory, elementFilter, layoutConfigurator);
+        const layoutPreprocessor = context.container.isBound(ILayoutPreprocessor)
+            ? context.container.get<ILayoutPreprocessor>(ILayoutPreprocessor) : undefined;
+        const layoutPostprocessor = context.container.isBound(ILayoutPostprocessor)
+            ? context.container.get<ILayoutPostprocessor>(ILayoutPostprocessor) : undefined;
+        return new ElkLayoutEngine(elkFactory, elementFilter, layoutConfigurator, layoutPreprocessor, layoutPostprocessor);
     }).inSingletonScope();
     bind(IElementFilter).to(DefaultElementFilter);
     bind(ILayoutConfigurator).to(DefaultLayoutConfigurator);


### PR DESCRIPTION
Closes #259.

Also improves extensibility of the ElkLayoutEngine:
 - Split `transformToElk` into multiple methods and deprecated the old one
 - Added optional ILayoutPreprocessor and ILayoutPostprocessor services