### PR TITLE
Add default layoutableChildFeature to SNodeImpl

### DIFF
--- a/packages/sprotty/src/graph/sgraph.ts
+++ b/packages/sprotty/src/graph/sgraph.ts
@@ -52,7 +52,7 @@ export class SGraphImpl extends ViewportRootElement {
  */
 export class SNodeImpl extends SConnectableElementImpl implements Selectable, Fadeable, Hoverable {
     static readonly DEFAULT_FEATURES = [connectableFeature, deletableFeature, selectFeature, boundsFeature,
-        moveFeature, layoutContainerFeature, fadeFeature, hoverFeedbackFeature, popupFeature];
+        moveFeature, layoutContainerFeature, fadeFeature, hoverFeedbackFeature, popupFeature, layoutableChildFeature];
 
     override children: SChildElementImpl[];
     layout?: string;


### PR DESCRIPTION
Adds the default feature `layoutableChildFeature` to `SNodeImpl` so that children of an `SNodeImpl` follow the node's layoutOptions by default.