### PR TITLE
Fix computation of bounding box with children rendered outside

### DIFF
--- a/examples/random-graph/css/diagram.css
+++ b/examples/random-graph/css/diagram.css
@@ -28,8 +28,20 @@
     stroke-width: 3;
 }
 
+.sprotty-port {
+    fill: #484;
+}
+
 .sprotty-edge {
     fill: none;
     stroke: #152;
     stroke-width: 1;
+}
+
+.sprotty-label.node {
+    font-size: 1.2rem;
+}
+
+.sprotty-label.port {
+    font-size: 0.8rem;
 }

--- a/examples/random-graph/src/di.config.ts
+++ b/examples/random-graph/src/di.config.ts
@@ -16,12 +16,18 @@
 
 import { Container, ContainerModule } from 'inversify';
 import ElkConstructor from 'elkjs/lib/elk.bundled';
+import { LayoutOptions } from 'elkjs/lib/elk-api';
 import {
     TYPES, configureViewerOptions, SGraphView, SLabelView, ConsoleLogger, LogLevel,
     loadDefaultModules, LocalModelSource, SNodeImpl, SEdgeImpl, SLabelImpl, configureModelElement,
-    SGraphImpl, RectangularNodeView, edgeIntersectionModule, PolylineEdgeViewWithGapsOnIntersections
+    SGraphImpl, RectangularNodeView, edgeIntersectionModule, PolylineEdgeViewWithGapsOnIntersections,
+    SPortImpl
 } from 'sprotty';
-import { ElkFactory, ElkLayoutEngine, elkLayoutModule } from 'sprotty-elk/lib/inversify';
+import {
+    DefaultLayoutConfigurator, ElkFactory, ElkLayoutEngine, ILayoutConfigurator, elkLayoutModule
+} from 'sprotty-elk/lib/inversify';
+import { SGraph, SModelIndex, SNode, SPort } from 'sprotty-protocol';
+import { PortViewWithExternalLabel } from './views';
 
 export default (containerId: string) => {
     require('sprotty/css/sprotty.css');
@@ -35,14 +41,17 @@ export default (containerId: string) => {
         bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
         bind(TYPES.IModelLayoutEngine).toService(ElkLayoutEngine);
         bind(ElkFactory).toConstantValue(elkFactory);
+        rebind(ILayoutConfigurator).to(RandomGraphLayoutConfigurator);
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
 
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(container, 'graph', SGraphImpl, SGraphView);
         configureModelElement(container, 'node', SNodeImpl, RectangularNodeView);
+        configureModelElement(container, 'port', SPortImpl, PortViewWithExternalLabel);
         configureModelElement(container, 'edge', SEdgeImpl, PolylineEdgeViewWithGapsOnIntersections);
-        configureModelElement(container, 'label', SLabelImpl, SLabelView);
+        configureModelElement(container, 'label:node', SLabelImpl, SLabelView);
+        configureModelElement(container, 'label:port', SLabelImpl, SLabelView);
 
         configureViewerOptions(context, {
             needsClientLayout: true,
@@ -56,3 +65,29 @@ export default (containerId: string) => {
     container.load(elkLayoutModule, randomGraphModule);
     return container;
 };
+
+export class RandomGraphLayoutConfigurator extends DefaultLayoutConfigurator {
+
+    protected override graphOptions(sgraph: SGraph, index: SModelIndex): LayoutOptions | undefined {
+        return {
+            'org.eclipse.elk.algorithm': 'org.eclipse.elk.layered'
+        };
+    }
+
+    protected override nodeOptions(snode: SNode, index: SModelIndex): LayoutOptions | undefined {
+        return {
+            'org.eclipse.elk.nodeSize.constraints': 'PORTS PORT_LABELS NODE_LABELS MINIMUM_SIZE',
+            'org.eclipse.elk.nodeSize.minimum': '(40, 40)',
+            'org.eclipse.elk.portConstraints': 'FREE',
+            'org.eclipse.elk.nodeLabels.placement': 'INSIDE H_CENTER V_TOP',
+            'org.eclipse.elk.portLabels.placement': 'OUTSIDE'
+        };
+    }
+
+    protected override portOptions(sport: SPort, index: SModelIndex): LayoutOptions | undefined {
+        return {
+            'org.eclipse.elk.port.borderOffset': '1'
+        };
+    }
+
+}

--- a/examples/random-graph/src/standalone.ts
+++ b/examples/random-graph/src/standalone.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { TYPES, LocalModelSource } from 'sprotty';
-import { SEdge, SGraph, SLabel, SNode } from 'sprotty-protocol';
+import { SEdge, SGraph, SLabel, SNode, SPort } from 'sprotty-protocol';
 import createContainer from './di.config';
 
 export default function runRandomGraph() {
@@ -39,10 +39,9 @@ function createRandomGraph(): SGraph {
         const node: SNode = {
             type: 'node',
             id: `node${i}`,
-            layout: 'vbox',
             children: [
                 <SLabel>{
-                    type: 'label',
+                    type: 'label:node',
                     id: `node${i}_label`,
                     text: i.toString()
                 }
@@ -52,13 +51,46 @@ function createRandomGraph(): SGraph {
     }
 
     for (let i = 0; i < EDGES; i++) {
+        const sourceNo = Math.floor(Math.random() * NODES);
+        const targetNo = Math.floor(Math.random() * NODES);
+        if (sourceNo === targetNo) {
+            continue;
+        }
         const edge: SEdge = {
             type: 'edge',
             id: `edge${i}`,
-            sourceId: `node${Math.floor(Math.random() * NODES)}`,
-            targetId: `node${Math.floor(Math.random() * NODES)}`
+            sourceId: `port${sourceNo}-${i}`,
+            targetId: `port${targetNo}-${i}`
         };
         graph.children.push(edge);
+
+        const sourcePort: SPort = {
+            type: 'port',
+            id: `port${sourceNo}-${i}`,
+            size: { width: 8, height: 8 },
+            children: [
+                <SLabel>{
+                    type: 'label:port',
+                    id: `port${sourceNo}-${i}-label`,
+                    text: `out${i}`
+                }
+            ]
+        };
+        graph.children.find(c => c.id === `node${sourceNo}`)!.children!.push(sourcePort);
+
+        const targetPort: SPort = {
+            type: 'port',
+            id: `port${targetNo}-${i}`,
+            size: { width: 8, height: 8 },
+            children: [
+                <SLabel>{
+                    type: 'label:port',
+                    id: `port${targetNo}-${i}-label`,
+                    text: `in${i}`
+                }
+            ]
+        };
+        graph.children.find(c => c.id === `node${targetNo}`)!.children!.push(targetPort);
     }
 
     return graph;

--- a/examples/random-graph/src/views.tsx
+++ b/examples/random-graph/src/views.tsx
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2023 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/** @jsx svg */
+import { svg } from 'sprotty/lib/lib/jsx';
+
+import { injectable } from 'inversify';
+import { VNode } from 'snabbdom';
+import { ATTR_BBOX_ELEMENT, RenderingContext, setAttr, ShapeView, SPortImpl } from 'sprotty';
+
+
+@injectable()
+export class PortViewWithExternalLabel extends ShapeView {
+    render(node: Readonly<SPortImpl>, context: RenderingContext): VNode | undefined {
+        if (!this.isVisible(node, context)) {
+            return undefined;
+        }
+        const bboxElement = <rect
+            class-sprotty-port={true}
+            class-mouseover={node.hoverFeedback} class-selected={node.selected}
+            x="0" y="0" width={Math.max(node.size.width, 0)} height={Math.max(node.size.height, 0)}>
+        </rect>;
+        setAttr(bboxElement, ATTR_BBOX_ELEMENT, true);
+        return <g>
+            {bboxElement}
+            {context.renderChildren(node)}
+        </g>;
+    }
+}

--- a/packages/sprotty/src/utils/browser.ts
+++ b/packages/sprotty/src/utils/browser.ts
@@ -64,3 +64,10 @@ export function hitsMouseEvent(child: Element, event: MouseEvent): boolean {
     return event.clientX >= clientRect.left && event.clientX <= clientRect.right
         && event.clientY >= clientRect.top && event.clientY <= clientRect.bottom;
 }
+
+/**
+ * Checks whether the given DOM node is an SVG element.
+ */
+export function isSVGGraphicsElement(node: Node): node is SVGGraphicsElement {
+    return typeof (node as SVGGraphicsElement).getBBox === 'function';
+}


### PR DESCRIPTION
Fixes #165.

I tried to find a generalization for the fix that would enable us to cover many use cases. The approach is to set a specific attribute to the SVG element that you'd like to use to determine the bounding box. Example:

https://github.com/eclipse-sprotty/sprotty/blob/9ff65633561a7c459e6e3662f0fabd45714f9182/examples/random-graph/src/views.tsx#L31-L40

I added ports with labels to the "Random Graph" example to show this.

Before the fix:
<img width="641" alt="Screenshot 2023-06-02 at 11 39 31" src="https://github.com/eclipse-sprotty/sprotty/assets/4067210/262a6b7c-c671-4d3a-b207-fdeddecf36ff">

After the fix:
<img width="685" alt="Screenshot 2023-06-02 at 12 16 16" src="https://github.com/eclipse-sprotty/sprotty/assets/4067210/31db59e4-71f7-4baf-9702-b46a2d4fa30a">
