### PR TITLE
Extracted `model` getter to abstract ModelSource

### DIFF
--- a/packages/sprotty/src/model-source/diagram-server.ts
+++ b/packages/sprotty/src/model-source/diagram-server.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { saveAs } from 'file-saver';
-import { inject, injectable } from "inversify";
+import { inject, injectable } from 'inversify';
 import { OpenAction, ActionMessage as ProtocolActionMessage, isActionMessage as isProtocolActionMessage } from 'sprotty-protocol';
 import {
     Action, CollapseExpandAction, CollapseExpandAllAction, ComputedBoundsAction, RequestModelAction,
@@ -23,15 +23,15 @@ import {
 } from 'sprotty-protocol/lib/actions';
 import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
-import { ActionHandlerRegistry } from "../base/actions/action-handler";
-import { ICommand } from "../base/commands/command";
-import { SetModelCommand } from "../base/features/set-model";
-import { TYPES } from "../base/types";
+import { ActionHandlerRegistry } from '../base/actions/action-handler';
+import { ICommand } from '../base/commands/command';
+import { SetModelCommand } from '../base/features/set-model';
+import { TYPES } from '../base/types';
 import { RequestBoundsCommand } from '../features/bounds/bounds-manipulation';
 import { ExportSvgAction } from '../features/export/svg-exporter';
-import { UpdateModelCommand } from "../features/update/update-model";
-import { ILogger } from "../utils/logging";
-import { ComputedBoundsApplicator, ModelSource } from "./model-source";
+import { UpdateModelCommand } from '../features/update/update-model';
+import { ILogger } from '../utils/logging';
+import { ComputedBoundsApplicator, ModelSource } from './model-source';
 
 /**
  * Sent by the external server when to signal a state change.
@@ -67,10 +67,14 @@ export abstract class DiagramServerProxy extends ModelSource {
 
     protected lastSubmittedModelType: string;
 
+    override get model(): SModelRootSchema {
+        return this.currentRoot;
+    }
+
     override initialize(registry: ActionHandlerRegistry): void {
         super.initialize(registry);
 
-        // Register this model source
+        // Register actions to be sent to the remote server
         registry.register(ComputedBoundsAction.KIND, this);
         registry.register(RequestBoundsCommand.KIND, this);
         registry.register(RequestPopupModelAction.KIND, this);
@@ -79,14 +83,16 @@ export abstract class DiagramServerProxy extends ModelSource {
         registry.register(OpenAction.KIND, this);
         registry.register(ServerStatusAction.KIND, this);
 
-        if (!this.clientId)
+        if (!this.clientId) {
             this.clientId = this.viewerOptions.baseDiv;
+        }
     }
 
     handle(action: Action): void | ICommand | Action {
         const forwardToServer = this.handleLocally(action);
-        if (forwardToServer)
+        if (forwardToServer) {
             this.forwardToServer(action);
+        }
     }
 
     protected forwardToServer(action: Action): void {
@@ -98,8 +104,14 @@ export abstract class DiagramServerProxy extends ModelSource {
         this.sendMessage(message);
     }
 
+    /**
+     * Send a message to the remote diagram server.
+     */
     protected abstract sendMessage(message: ProtocolActionMessage): void;
 
+    /**
+     * Called when a message is received from the remote diagram server.
+     */
     protected messageReceived(data: any): void {
         const object = typeof(data) === 'string' ? JSON.parse(data) : data;
         if (isProtocolActionMessage(object) && object.action) {
@@ -188,8 +200,8 @@ export abstract class DiagramServerProxy extends ModelSource {
     }
 
     protected handleExportSvgAction(action: ExportSvgAction): boolean {
-        const blob = new Blob([action.svg], {type: "text/plain;charset=utf-8"});
-        saveAs(blob, "diagram.svg");
+        const blob = new Blob([action.svg], { type: 'text/plain;charset=utf-8' });
+        saveAs(blob, 'diagram.svg');
         return false;
     }
 

--- a/packages/sprotty/src/model-source/local-model-source.ts
+++ b/packages/sprotty/src/model-source/local-model-source.ts
@@ -58,7 +58,7 @@ export class LocalModelSource extends ModelSource {
      */
     protected lastSubmittedModelType: string;
 
-    get model(): SModelRootSchema {
+    override get model(): SModelRootSchema {
         return this.currentRoot;
     }
 
@@ -69,7 +69,7 @@ export class LocalModelSource extends ModelSource {
     override initialize(registry: ActionHandlerRegistry): void {
         super.initialize(registry);
 
-        // Register this model source
+        // Register actions to be handled by the `handle` method
         registry.register(ComputedBoundsAction.KIND, this);
         registry.register(RequestPopupModelAction.KIND, this);
     }
@@ -196,12 +196,12 @@ export class LocalModelSource extends ModelSource {
         const matches: Match[] = [];
         for (const e of elements) {
             const anye: any = e;
-            if (anye.element !== undefined && anye.parentId !== undefined) {
+            if (typeof anye.element === 'object' && typeof anye.parentId === 'string') {
                 matches.push({
                     right: anye.element,
                     rightParentId: anye.parentId
                 });
-            } else if (anye.id !== undefined) {
+            } else if (typeof anye.id === 'string') {
                 matches.push({
                     right: anye,
                     rightParentId: this.currentRoot.id

--- a/packages/sprotty/src/model-source/model-source.ts
+++ b/packages/sprotty/src/model-source/model-source.ts
@@ -31,18 +31,18 @@ import { ExportSvgAction } from '../features/export/svg-exporter';
  * the entry point to the client for external sources, such as model
  * editors.
  *
- * As an IActionHandler it listens to actions in and reacts to them with
+ * As an `IActionHandler` it listens to actions in and reacts to them with
  * commands or actions if necessary. This way, you can implement action
  * protocols between the client and the outside world.
  *
  * There are two default implementations for a ModelSource:
- * <ul>
- * <li>the LocalModelSource handles the actions to calculate bounds and
- * set/update the model</li>
- * <li>the DiagramServer connects via websocket to a remote source. It
- * can be used to connect to a model editor that provides the model,
- * layouts diagrams, transfers selection and answers model queries from
- * the client.</li>
+ *
+ *  - The `LocalModelSource` handles the actions to calculate bounds and
+ *    set/update the model
+ *  - the `DiagramServerProxy` connects via websocket to a remote source.
+ *    It can be used to connect to a model editor that provides the model,
+ *    layouts diagrams, transfers selection and answers model queries from
+ *    the client.
  */
 @injectable()
 export abstract class ModelSource implements IActionHandler, IActionHandlerInitializer {
@@ -55,6 +55,8 @@ export abstract class ModelSource implements IActionHandler, IActionHandlerIniti
         registry.register(RequestModelAction.KIND, this);
         registry.register(ExportSvgAction.KIND, this);
     }
+
+    abstract get model(): SModelRootSchema;
 
     abstract handle(action: Action): ICommand | Action | void;
 


### PR DESCRIPTION
I noticed quite often that the implementation of certain custom functionality requires access to the external model. This change makes the external model available in the `ModelSource` base class by exposing the `model` getter property. Also some code cleanup and commenting on the way.