### PR TITLE
Deprecate tool manager API

### DIFF
--- a/packages/sprotty/src/base/di.config.ts
+++ b/packages/sprotty/src/base/di.config.ts
@@ -19,7 +19,7 @@ import { TYPES } from "./types";
 import { CanvasBoundsInitializer, InitializeCanvasBoundsCommand } from './features/initialize-canvas';
 import { LogLevel, NullLogger } from "../utils/logging";
 import { ActionDispatcher, IActionDispatcher } from "./actions/action-dispatcher";
-import { ActionHandlerRegistry, configureActionHandler } from "./actions/action-handler";
+import { ActionHandlerRegistry } from "./actions/action-handler";
 import { CommandStack, ICommandStack } from "./commands/command-stack";
 import { CommandStackOptions } from "./commands/command-stack-options";
 import { SModelFactory, SModelRegistry } from './model/smodel-factory';
@@ -35,8 +35,6 @@ import { DOMHelper } from "./views/dom-helper";
 import { IdPostprocessor } from "./views/id-postprocessor";
 import { configureCommand, CommandActionHandlerInitializer } from "./commands/command-registration";
 import { CssClassPostprocessor } from "./views/css-class-postprocessor";
-import { ToolManager, DefaultToolsEnablingKeyListener, ToolManagerActionHandler } from "./tool-manager/tool-manager";
-import { EnableDefaultToolsAction, EnableToolsAction } from "./tool-manager/tool";
 import { SetModelCommand } from "./features/set-model";
 import { UIExtensionRegistry, SetUIExtensionVisibilityCommand } from "./ui-extensions/ui-extension-registry";
 import { DefaultDiagramLocker } from "./actions/diagram-locker";
@@ -157,14 +155,6 @@ const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
 
     // Model commands ---------------------------------------------
     configureCommand(context, SetModelCommand);
-
-    // Tool manager initialization ------------------------------------
-    bind(TYPES.IToolManager).to(ToolManager).inSingletonScope();
-    bind(DefaultToolsEnablingKeyListener).toSelf().inSingletonScope();
-    bind(TYPES.KeyListener).toService(DefaultToolsEnablingKeyListener);
-    bind(ToolManagerActionHandler).toSelf().inSingletonScope();
-    configureActionHandler(context, EnableDefaultToolsAction.KIND, ToolManagerActionHandler);
-    configureActionHandler(context, EnableToolsAction.KIND, ToolManagerActionHandler);
 
     // UIExtension registry initialization ------------------------------------
     bind(TYPES.UIExtensionRegistry).to(UIExtensionRegistry).inSingletonScope();

--- a/packages/sprotty/src/base/tool-manager/tool-manager.ts
+++ b/packages/sprotty/src/base/tool-manager/tool-manager.ts
@@ -29,6 +29,7 @@ import { matchesKeystroke } from "../../utils/keyboard";
  * One instance of a tool manager is intended per editor, coordinating the state of all tools within
  * this editor. A tool can be active or not. A tool manager ensures that activating a set of tools
  * will disable all other tools, allowing them to invoke behavior when they become enabled or disabled.
+ * @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported
  */
 export interface IToolManager {
 
@@ -66,6 +67,9 @@ export interface IToolManager {
     registerTools(...tools: Tool[]): void;
 }
 
+/**
+ * @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported
+ */
 @injectable()
 export class ToolManager implements IToolManager {
 
@@ -118,6 +122,9 @@ export class ToolManager implements IToolManager {
     }
 }
 
+/**
+ * @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported
+ */
 @injectable()
 export class ToolManagerActionHandler implements IActionHandler {
     @inject(TYPES.IToolManager)
@@ -135,6 +142,9 @@ export class ToolManagerActionHandler implements IActionHandler {
     }
 }
 
+/**
+ * @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported
+ */
 @injectable()
 export class DefaultToolsEnablingKeyListener extends KeyListener {
     override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {

--- a/packages/sprotty/src/base/tool-manager/tool.ts
+++ b/packages/sprotty/src/base/tool-manager/tool.ts
@@ -18,6 +18,7 @@ import { Action } from "sprotty-protocol/lib/actions";
 
 /**
  * Action to enable the tools of the specified `toolIds`.
+ * @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported
  */
 export interface EnableToolsAction extends Action {
     kind: typeof EnableToolsAction.KIND
@@ -36,6 +37,7 @@ export namespace EnableToolsAction {
 
 /**
  * Action to disable the currently active tools and enable the default tools instead.
+ * @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported
  */
 export interface EnableDefaultToolsAction extends Action {
     kind: typeof EnableDefaultToolsAction.KIND;
@@ -50,7 +52,9 @@ export namespace EnableDefaultToolsAction {
     }
 }
 
-/** A tool that can be managed by a `ToolManager`. */
+/** A tool that can be managed by a `ToolManager`.
+ * @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported
+ */
 export interface Tool {
     readonly id: string;
     /* Notifies the tool to become active. */

--- a/packages/sprotty/src/base/types.ts
+++ b/packages/sprotty/src/base/types.ts
@@ -24,8 +24,6 @@ export const TYPES = {
     ActionHandlerRegistryProvider: Symbol('ActionHandlerRegistryProvider'),
     IAnchorComputer: Symbol('IAnchor'),
     AnimationFrameSyncer: Symbol('AnimationFrameSyncer'),
-    /** @deprecated deprecated since 0.12.0 - please use `configureButtonHandler` */
-    IButtonHandler: Symbol('IButtonHandler'),
     IButtonHandlerRegistration: Symbol('IButtonHandlerRegistration'),
     ICommandPaletteActionProvider: Symbol('ICommandPaletteActionProvider'),
     ICommandPaletteActionProviderRegistry: Symbol('ICommandPaletteActionProviderRegistry'),
@@ -68,7 +66,6 @@ export const TYPES = {
     SModelRegistry: Symbol('SModelRegistry'),
     ISnapper: Symbol('ISnapper'),
     SvgExporter: Symbol('SvgExporter'),
-    IToolManager: Symbol('IToolManager'),
     IUIExtension: Symbol('IUIExtension'),
     UIExtensionRegistry: Symbol('UIExtensionRegistry'),
     IVNodePostprocessor: Symbol('IVNodePostprocessor'),
@@ -77,5 +74,9 @@ export const TYPES = {
     IViewer: Symbol('IViewer'),
     ViewerOptions: Symbol('ViewerOptions'),
     IViewerProvider: Symbol('IViewerProvider'),
+    /** @deprecated deprecated since 0.12.0 - please use `configureButtonHandler` */
+    IButtonHandler: Symbol('IButtonHandler'),
+    /** @deprecated `deprecated since 0.14.0 - the Tool/Toolmanager API is no longer supported */
+    IToolManager: Symbol('IToolManager')
 };
 /* eslint-enable */


### PR DESCRIPTION
Deprecate tool manager API as the entire concept is unused in sprotty and should rather be contributed directly by GLSP. Remove related bindings from default module.
Closes #235