### PR TITLE
Fix command palette suggestion position

### DIFF
--- a/packages/sprotty/src/features/command-palette/command-palette.ts
+++ b/packages/sprotty/src/features/command-palette/command-palette.ts
@@ -207,6 +207,7 @@ export class CommandPalette extends AbstractUIExtension {
 
     protected customizeSuggestionContainer(container: HTMLDivElement, inputRect: ClientRect | DOMRect, maxHeight: number) {
         // move container into our command palette container as this is already positioned correctly
+        container.style.position = "fixed";
         if (this.containerElement) {
             this.containerElement.appendChild(container);
         }


### PR DESCRIPTION
Fix the position of the command palette suggestion box by setting the position to "fixed". This seems to be broken since the version bump form commander to version 7.0.1 (https://github.com/eclipse-sprotty/sprotty/pull/329).

Current Master:

![Screenshot from 2023-08-22 12-05-25](https://github.com/eclipse-sprotty/sprotty/assets/2311075/18d1aae3-4941-48ad-b6d5-42d16a386ea1)

This PR:
![Screenshot from 2023-08-22 12-05-35](https://github.com/eclipse-sprotty/sprotty/assets/2311075/e8aa5a99-9a8c-4ef1-bb8f-126c9e0e2191)
