### PR TITLE
Layout configuration for the random graph example

### DIFF
--- a/examples/random-graph/random-graph.html
+++ b/examples/random-graph/random-graph.html
@@ -14,6 +14,15 @@
         <div class="row" id="sprotty-app" data-app="random-graph">
             <div class="col-md-10">
                 <h1>Sprotty Random Graph Example</h1>
+                <p>
+                    <label for="direction">Layout Direction:</label>
+                    <select id="direction" name="direction">
+                        <option value="LEFT">Left</option>
+                        <option value="DOWN">Down</option>
+                        <option value="RIGHT">Right</option>
+                        <option value="UP">Up</option>
+                      </select>
+                </p>
             </div>
             <div class="help col-md-2">
                 <a href='https://github.com/eclipse/sprotty/wiki/Using-sprotty'>Help</a>

--- a/examples/random-graph/src/di.config.ts
+++ b/examples/random-graph/src/di.config.ts
@@ -41,7 +41,8 @@ export default (containerId: string) => {
         bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
         bind(TYPES.IModelLayoutEngine).toService(ElkLayoutEngine);
         bind(ElkFactory).toConstantValue(elkFactory);
-        rebind(ILayoutConfigurator).to(RandomGraphLayoutConfigurator);
+        bind(RandomGraphLayoutConfigurator).toSelf().inSingletonScope();
+        rebind(ILayoutConfigurator).to(RandomGraphLayoutConfigurator).inSingletonScope();
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
 
@@ -68,9 +69,16 @@ export default (containerId: string) => {
 
 export class RandomGraphLayoutConfigurator extends DefaultLayoutConfigurator {
 
+    direction: 'UP' | 'DOWN' | 'LEFT' | 'RIGHT' = 'LEFT';
+
+    public setDirection(direction: 'UP' | 'DOWN' | 'LEFT' | 'RIGHT'): void {
+        this.direction = direction;
+    }
+
     protected override graphOptions(sgraph: SGraph, index: SModelIndex): LayoutOptions | undefined {
         return {
-            'org.eclipse.elk.algorithm': 'org.eclipse.elk.layered'
+            'org.eclipse.elk.algorithm': 'org.eclipse.elk.layered',
+            'elk.direction': this.direction
         };
     }
 

--- a/examples/random-graph/src/di.config.ts
+++ b/examples/random-graph/src/di.config.ts
@@ -14,19 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Container, ContainerModule } from 'inversify';
-import ElkConstructor from 'elkjs/lib/elk.bundled';
 import { LayoutOptions } from 'elkjs/lib/elk-api';
+import ElkConstructor from 'elkjs/lib/elk.bundled';
+import { Container, ContainerModule } from 'inversify';
 import {
-    TYPES, configureViewerOptions, SGraphView, SLabelView, ConsoleLogger, LogLevel,
-    loadDefaultModules, LocalModelSource, SNodeImpl, SEdgeImpl, SLabelImpl, configureModelElement,
-    SGraphImpl, RectangularNodeView, edgeIntersectionModule, PolylineEdgeViewWithGapsOnIntersections,
-    SPortImpl
+    Animation, CommandExecutionContext, configureModelElement, configureViewerOptions, ConsoleLogger,
+    edgeIntersectionModule, isSelectable, isViewport, loadDefaultModules, LocalModelSource, LogLevel, PolylineEdgeViewWithGapsOnIntersections,
+    RectangularNodeView, SEdgeImpl, SGraphImpl, SGraphView, SLabelImpl, SLabelView, SModelRootImpl, SNodeImpl, SPortImpl,
+    TYPES, UpdateAnimationData, UpdateModelCommand, ViewportAnimation
 } from 'sprotty';
 import {
-    DefaultLayoutConfigurator, ElkFactory, ElkLayoutEngine, ILayoutConfigurator, elkLayoutModule
+    DefaultLayoutConfigurator, ElkFactory, ElkLayoutEngine, elkLayoutModule, ILayoutConfigurator
 } from 'sprotty-elk/lib/inversify';
-import { SGraph, SModelIndex, SNode, SPort } from 'sprotty-protocol';
+import { Point, SGraph, SModelIndex, SNode, SPort } from 'sprotty-protocol';
 import { PortViewWithExternalLabel } from './views';
 
 export default (containerId: string) => {
@@ -45,6 +45,7 @@ export default (containerId: string) => {
         rebind(ILayoutConfigurator).to(RandomGraphLayoutConfigurator).inSingletonScope();
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
+        rebind(UpdateModelCommand).to(TrackSelectedUpdateModelCommand);
 
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(container, 'graph', SGraphImpl, SGraphView);
@@ -98,4 +99,27 @@ export class RandomGraphLayoutConfigurator extends DefaultLayoutConfigurator {
         };
     }
 
+}
+
+/**
+ * Moves the viewport so that the selected element stays at the same position on the screen.
+ */
+export class TrackSelectedUpdateModelCommand extends UpdateModelCommand {
+
+    override createAnimations(data: UpdateAnimationData, root: SModelRootImpl, context: CommandExecutionContext): Animation[] {
+        const animations = super.createAnimations(data, root, context);
+        const selectedToMove = data.moves?.find(toMove => isSelectable(toMove.element) && toMove.element.selected)
+        if (isViewport(root) && selectedToMove) {
+            const nodeMove: Point = {
+                x: selectedToMove.fromPosition.x - selectedToMove.toPosition.x,
+                y: selectedToMove.fromPosition.y - selectedToMove.toPosition.y
+            };
+            const { scroll, zoom } = root;
+            animations.push(new ViewportAnimation(root,
+                { scroll, zoom },
+                { scroll: { x: scroll.x - nodeMove.x, y: scroll.y - nodeMove.y }, zoom }, context)
+            );
+        }
+        return animations;
+    }
 }

--- a/examples/random-graph/src/standalone.ts
+++ b/examples/random-graph/src/standalone.ts
@@ -14,15 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { TYPES, LocalModelSource } from 'sprotty';
+import { LocalModelSource, TYPES } from 'sprotty';
+import { ILayoutConfigurator } from 'sprotty-elk/lib/inversify';
 import { SEdge, SGraph, SLabel, SNode, SPort } from 'sprotty-protocol';
-import createContainer from './di.config';
+import createContainer, { RandomGraphLayoutConfigurator } from './di.config';
 
 export default function runRandomGraph() {
     const container = createContainer('sprotty');
 
     const modelSource = container.get<LocalModelSource>(TYPES.ModelSource);
     modelSource.setModel(createRandomGraph());
+
+    const layoutConfigurator = container.get<RandomGraphLayoutConfigurator>(ILayoutConfigurator);
+    document.getElementById('direction')!.addEventListener('change', async (event) => {
+        layoutConfigurator.setDirection((event.target as any)?.value??'LEFT');
+        modelSource.updateModel();
+    });
 }
 
 const NODES = 50;
@@ -92,6 +99,5 @@ function createRandomGraph(): SGraph {
         };
         graph.children.find(c => c.id === `node${targetNo}`)!.children!.push(targetPort);
     }
-
     return graph;
 }


### PR DESCRIPTION
Now the use can choose between Left/Right/Top/Down directions.
Another tweak demonstrates how to keep a selected node in place when the layout is changing. To test, select a node and change the layout direction. Selected node should remain in the same place. 

