### PR TITLE
Fix typing of RequestActions

### DIFF
--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -50,6 +50,11 @@ export function isAction(object?: unknown): object is Action {
  */
 export interface RequestAction<Res extends ResponseAction> extends Action {
     requestId: string
+
+    /**
+     * Used to ensure correct typing. Clients must not use this property
+     */
+    readonly _?: Res;
 }
 
 export function isRequestAction(object?: Action): object is RequestAction<ResponseAction> {
@@ -607,7 +612,7 @@ export namespace ViewportResult {
 /**
  * Action to render the selected elements in front of others by manipulating the z-order.
  */
- export interface BringToFrontAction extends Action {
+export interface BringToFrontAction extends Action {
     kind: typeof BringToFrontAction.KIND;
     elementIDs: string[]
 }


### PR DESCRIPTION
Add an artificial property to the `RequestAction` definition to ensure that the generic type literal is not unused. This ensure that the TS compiler has all required type information and can implicitly derive the type of the Response action from a request action.

Fixes https://github.com/eclipse-sprotty/sprotty/issues/378