### PR TITLE
Renamed ViewportRootElement

### DIFF
--- a/examples/multicore/src/chipmodel.ts
+++ b/examples/multicore/src/chipmodel.ts
@@ -17,7 +17,7 @@
 import {
     SShapeElementImpl, SChildElementImpl, BoundsAware, boundsFeature, Fadeable, fadeFeature,
     layoutContainerFeature, LayoutContainer, Selectable, selectFeature,
-    ViewportRootElement, hoverFeedbackFeature, Hoverable, popupFeature
+    ViewportRootElementImpl, hoverFeedbackFeature, Hoverable, popupFeature
 } from 'sprotty';
 import { Bounds, SModelElement, SModelRoot, JsonMap, SShapeElement } from 'sprotty-protocol';
 
@@ -31,8 +31,8 @@ export interface ProcessorSchema extends SModelRoot {
     columns: number
 }
 
-export class Processor extends ViewportRootElement implements BoundsAware {
-    static override readonly DEFAULT_FEATURES = [...ViewportRootElement.DEFAULT_FEATURES, boundsFeature];
+export class Processor extends ViewportRootElementImpl implements BoundsAware {
+    static override readonly DEFAULT_FEATURES = [...ViewportRootElementImpl.DEFAULT_FEATURES, boundsFeature];
 
     rows: number = 0;
     columns: number = 0;

--- a/examples/svg/src/di.config.ts
+++ b/examples/svg/src/di.config.ts
@@ -17,7 +17,7 @@
 import { Container, ContainerModule } from 'inversify';
 import {
     TYPES, ConsoleLogger, LogLevel, loadDefaultModules, LocalModelSource, PreRenderedView,
-    ProjectedViewportView, ViewportRootElement, ShapedPreRenderedElementImpl, configureModelElement,
+    ProjectedViewportView, ViewportRootElementImpl, ShapedPreRenderedElementImpl, configureModelElement,
     ForeignObjectElementImpl, ForeignObjectView, RectangularNode, RectangularNodeView, moveFeature,
     selectFeature, EditableLabel, editLabelFeature, WithEditableLabel, withEditLabelFeature,
     isEditableLabel, configureViewerOptions
@@ -34,7 +34,7 @@ export default () => {
         bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
         const context = { bind, unbind, isBound, rebind };
 
-        configureModelElement(context, 'svg', ViewportRootElement, ProjectedViewportView);
+        configureModelElement(context, 'svg', ViewportRootElementImpl, ProjectedViewportView);
         configureModelElement(context, 'pre-rendered', ShapedPreRenderedElementImpl, PreRenderedView);
         configureModelElement(context, 'foreign-object', ForeignObjectElementImpl, ForeignObjectView);
         configureModelElement(context, 'node', RectangleWithEditableLabel, RectangularNodeView, {

--- a/examples/svg/src/standalone.ts
+++ b/examples/svg/src/standalone.ts
@@ -14,11 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import {
-    TYPES, ViewportRootElementSchema, Projectable, LocalModelSource
-} from 'sprotty';
+import { TYPES, Projectable, LocalModelSource } from 'sprotty';
 import createContainer from './di.config';
-import { ForeignObjectElement, SShapeElement, ShapedPreRenderedElement } from 'sprotty-protocol';
+import { ForeignObjectElement, SShapeElement, ShapedPreRenderedElement, ViewportRootElement } from 'sprotty-protocol';
 
 function loadFile(path: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
@@ -40,7 +38,7 @@ export default async function runSVG() {
     const container = createContainer();
 
     // Initialize model
-    const model: ViewportRootElementSchema = {
+    const model: ViewportRootElement = {
         type: 'svg',
         id: 'root',
         children: [

--- a/packages/sprotty-protocol/src/model.ts
+++ b/packages/sprotty-protocol/src/model.ts
@@ -60,6 +60,16 @@ export interface Viewport extends Scrollable, Zoomable {
 }
 
 /**
+ * Usually the root of a model is also a viewport.
+ */
+export interface ViewportRootElement extends SModelRoot {
+    scroll?: Point
+    zoom?: number
+    position?: Point
+    size?: Dimension
+}
+
+/**
  * A scrollable element has a scroll position, which indicates the top left corner of the
  * visible area.
  */

--- a/packages/sprotty/src/base/commands/command.ts
+++ b/packages/sprotty/src/base/commands/command.ts
@@ -181,7 +181,7 @@ export interface CommandExecutionContext {
     /** The current Sprotty model (i.e. the main model that is visible to the user) */
     root: SModelRootImpl
 
-    /** Used to turn sprotty schema elements (e.g. from the action) into model elements */
+    /** Used to turn sprotty external model elements (e.g. from the action) into internal model elements */
     modelFactory: IModelFactory
 
     /** Allows to give some feedback to the console */

--- a/packages/sprotty/src/features/bounds/views.spec.ts
+++ b/packages/sprotty/src/features/bounds/views.spec.ts
@@ -17,7 +17,7 @@
 import 'mocha';
 import { expect } from "chai";
 import { IViewArgs, RenderingContext } from '../../base/views/view';
-import { ViewportRootElement } from '../viewport/viewport-root';
+import { ViewportRootElementImpl } from '../viewport/viewport-root';
 import { SShapeElementImpl } from './model';
 import { ShapeView } from './views';
 import { VNode } from 'snabbdom';
@@ -33,8 +33,8 @@ describe('ShapeView.isVisible', () => {
         }
     }
 
-    function createModel(): ViewportRootElement {
-        const root = new ViewportRootElement();
+    function createModel(): ViewportRootElementImpl {
+        const root = new ViewportRootElementImpl();
         root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
         const node1 = new TestNode();
         node1.bounds = { x: 100, y: 100, width: 100, height: 100 };

--- a/packages/sprotty/src/features/projection/views.tsx
+++ b/packages/sprotty/src/features/projection/views.tsx
@@ -22,7 +22,7 @@ import { VNode, VNodeStyle, h } from 'snabbdom';
 import { Bounds } from 'sprotty-protocol/lib/utils/geometry';
 import { IView, IViewArgs, RenderingContext } from '../../base/views/view';
 import { setAttr, setClass } from '../../base/views/vnode-utils';
-import { ViewportRootElement } from '../viewport/viewport-root';
+import { ViewportRootElementImpl } from '../viewport/viewport-root';
 import { getModelBounds, getProjections, ViewProjection } from './model';
 
 /**
@@ -31,7 +31,7 @@ import { getModelBounds, getProjections, ViewProjection } from './model';
 @injectable()
 export class ProjectedViewportView implements IView {
 
-    render(model: Readonly<ViewportRootElement>, context: RenderingContext, args?: IViewArgs): VNode {
+    render(model: Readonly<ViewportRootElementImpl>, context: RenderingContext, args?: IViewArgs): VNode {
         const rootNode: VNode = <div class-sprotty-root={true}>
             {this.renderSvg(model, context, args)}
             {this.renderProjections(model, context, args)}
@@ -40,13 +40,13 @@ export class ProjectedViewportView implements IView {
         return rootNode;
     }
 
-    protected renderSvg(model: Readonly<ViewportRootElement>, context: RenderingContext, args?: IViewArgs): VNode {
+    protected renderSvg(model: Readonly<ViewportRootElementImpl>, context: RenderingContext, args?: IViewArgs): VNode {
         const transform = `scale(${model.zoom}) translate(${-model.scroll.x},${-model.scroll.y})`;
         const ns = 'http://www.w3.org/2000/svg';
         return h('svg', { ns }, h('g', { ns, attrs: { transform } }, context.renderChildren(model)));
     }
 
-    protected renderProjections(model: Readonly<ViewportRootElement>, context: RenderingContext, args?: IViewArgs): VNode[] {
+    protected renderProjections(model: Readonly<ViewportRootElementImpl>, context: RenderingContext, args?: IViewArgs): VNode[] {
         if (model.zoom <= 0) {
             return [];
         }
@@ -61,7 +61,7 @@ export class ProjectedViewportView implements IView {
         ];
     }
 
-    protected renderProjectionBar(projections: ViewProjection[], model: Readonly<ViewportRootElement>, modelBounds: Bounds, orientation: 'horizontal' | 'vertical'): VNode {
+    protected renderProjectionBar(projections: ViewProjection[], model: Readonly<ViewportRootElementImpl>, modelBounds: Bounds, orientation: 'horizontal' | 'vertical'): VNode {
         const params: ProjectionParams = { modelBounds, orientation } as ProjectionParams;
         // NOTE: Here we assume that the projection bars have the same size as the diagram canvas, i.e. they are drawn as overlay above the canvas.
         params.factor = orientation === 'horizontal' ? model.canvasBounds.width / modelBounds.width : model.canvasBounds.height / modelBounds.height;
@@ -75,7 +75,7 @@ export class ProjectedViewportView implements IView {
         </div>;
     }
 
-    protected renderViewport(model: Readonly<ViewportRootElement>, params: ProjectionParams): VNode {
+    protected renderViewport(model: Readonly<ViewportRootElementImpl>, params: ProjectionParams): VNode {
         let canvasSize, viewportPos: number;
         if (params.orientation === 'horizontal') {
             canvasSize = model.canvasBounds.width;
@@ -106,7 +106,7 @@ export class ProjectedViewportView implements IView {
         return <div class-sprotty-viewport={true} style={style} />;
     }
 
-    protected renderProjection(projection: ViewProjection, model: Readonly<ViewportRootElement>, params: ProjectionParams): VNode {
+    protected renderProjection(projection: ViewProjection, model: Readonly<ViewportRootElementImpl>, params: ProjectionParams): VNode {
         let canvasSize, projPos, projSize: number;
         if (params.orientation === 'horizontal') {
             canvasSize = model.canvasBounds.width;

--- a/packages/sprotty/src/features/routing/views.spec.ts
+++ b/packages/sprotty/src/features/routing/views.spec.ts
@@ -18,7 +18,7 @@ import 'mocha';
 import { expect } from "chai";
 import { IViewArgs, RenderingContext } from '../../base/views/view';
 import { SShapeElementImpl } from '../bounds/model';
-import { ViewportRootElement } from '../viewport/viewport-root';
+import { ViewportRootElementImpl } from '../viewport/viewport-root';
 import { SRoutableElementImpl } from './model';
 import { RoutableView } from './views';
 import { VNode } from 'snabbdom';
@@ -37,8 +37,8 @@ describe('RoutableView.isVisible', () => {
         }
     }
 
-    function createModel(): ViewportRootElement {
-        const root = new ViewportRootElement();
+    function createModel(): ViewportRootElementImpl {
+        const root = new ViewportRootElementImpl();
         root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
         const node1 = new TestNode();
         node1.bounds = { x: 100, y: 100, width: 100, height: 100 };

--- a/packages/sprotty/src/features/update/update-model.ts
+++ b/packages/sprotty/src/features/update/update-model.ts
@@ -25,7 +25,7 @@ import { MoveAnimation, ResolvedElementMove, MorphEdgesAnimation } from '../move
 import { Fadeable, isFadeable } from '../fade/model';
 import { isLocateable } from '../move/model';
 import { isSizeable } from '../bounds/model';
-import { ViewportRootElement } from '../viewport/viewport-root';
+import { ViewportRootElementImpl } from '../viewport/viewport-root';
 import { isSelectable } from '../select/model';
 import { MatchResult, ModelMatcher, Match, forEachMatch } from './model-matching';
 import { ResolvedElementResize, ResizeAnimation } from '../bounds/resize';
@@ -241,7 +241,7 @@ export class UpdateModelCommand extends Command {
         if (left instanceof SModelRootImpl && right instanceof SModelRootImpl) {
             right.canvasBounds = left.canvasBounds;
         }
-        if (left instanceof ViewportRootElement && right instanceof ViewportRootElement) {
+        if (left instanceof ViewportRootElementImpl && right instanceof ViewportRootElementImpl) {
             right.scroll = left.scroll;
             right.zoom = left.zoom;
         }

--- a/packages/sprotty/src/features/viewport/viewport-root.ts
+++ b/packages/sprotty/src/features/viewport/viewport-root.ts
@@ -14,25 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelRoot, Viewport } from 'sprotty-protocol/lib/model';
+import { Viewport } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, isBounds, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SModelRootImpl, ModelIndexImpl } from '../../base/model/smodel';
 import { viewportFeature } from "./model";
 import { exportFeature } from "../export/model";
 import { BoundsAware } from "../bounds/model";
 
-export interface ViewportRootElementSchema extends SModelRoot {
-    scroll?: Point
-    zoom?: number
-    position?: Point
-    size?: Dimension
-}
-
 /**
  * Model root element that defines a viewport, so it transforms the coordinate system with
  * a `scroll` translation and a `zoom` scaling.
  */
-export class ViewportRootElement extends SModelRootImpl implements Viewport, BoundsAware {
+export class ViewportRootElementImpl extends SModelRootImpl implements Viewport, BoundsAware {
     static readonly DEFAULT_FEATURES = [viewportFeature, exportFeature];
 
     scroll: Point = { x: 0, y: 0 };

--- a/packages/sprotty/src/features/viewport/viewport.spec.ts
+++ b/packages/sprotty/src/features/viewport/viewport.spec.ts
@@ -23,7 +23,7 @@ import { ConsoleLogger } from '../../utils/logging';
 import { AnimationFrameSyncer } from '../../base/animations/animation-frame-syncer';
 import { CommandExecutionContext } from '../../base/commands/command';
 import { SetViewportCommand } from './viewport';
-import { ViewportRootElement } from './viewport-root';
+import { ViewportRootElementImpl } from './viewport-root';
 import defaultModule from '../../base/di.config';
 import { SetViewportAction, Viewport, almostEquals } from 'sprotty-protocol';
 import { IModelFactory } from '../../base/model/smodel-factory';
@@ -40,7 +40,7 @@ describe('BoundsAwareViewportCommand', () => {
     const graphFactory = container.get<IModelFactory>(TYPES.IModelFactory);
 
     const viewportData: Viewport = { scroll: { x: 0, y: 0 }, zoom: 1 };
-    const viewport: ViewportRootElement = graphFactory.createRoot({ id: 'viewport1', type: 'graph', children: [] }) as ViewportRootElement;
+    const viewport: ViewportRootElementImpl = graphFactory.createRoot({ id: 'viewport1', type: 'graph', children: [] }) as ViewportRootElementImpl;
     viewport.zoom = viewportData.zoom;
     viewport.scroll = viewportData.scroll;
 

--- a/packages/sprotty/src/graph/sgraph.ts
+++ b/packages/sprotty/src/graph/sgraph.ts
@@ -28,13 +28,13 @@ import { Hoverable, hoverFeedbackFeature, popupFeature } from '../features/hover
 import { moveFeature } from '../features/move/model';
 import { connectableFeature, SConnectableElementImpl, SRoutableElementImpl } from '../features/routing/model';
 import { Selectable, selectFeature } from '../features/select/model';
-import { ViewportRootElement } from '../features/viewport/viewport-root';
+import { ViewportRootElementImpl } from '../features/viewport/viewport-root';
 import { FluentIterable, FluentIterableImpl } from '../utils/iterable';
 
 /**
  * Root element for graph-like models.
  */
-export class SGraphImpl extends ViewportRootElement {
+export class SGraphImpl extends ViewportRootElementImpl {
     layoutOptions?: ModelLayoutOptions;
 
     constructor(index = new SGraphIndex()) {

--- a/packages/sprotty/src/lib/svg-views.tsx
+++ b/packages/sprotty/src/lib/svg-views.tsx
@@ -21,7 +21,7 @@ import { VNode } from "snabbdom";
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { IView, IViewArgs, RenderingContext } from "../base/views/view";
 import { SNodeImpl, SPortImpl } from "../graph/sgraph";
-import { ViewportRootElement } from "../features/viewport/viewport-root";
+import { ViewportRootElementImpl } from "../features/viewport/viewport-root";
 import { SShapeElementImpl } from '../features/bounds/model';
 import { ShapeView } from '../features/bounds/views';
 import { Hoverable } from '../features/hover/model';
@@ -32,7 +32,7 @@ import { injectable } from 'inversify';
 
 @injectable()
 export class SvgViewportView implements IView {
-    render(model: Readonly<ViewportRootElement>, context: RenderingContext, args?: IViewArgs): VNode {
+    render(model: Readonly<ViewportRootElementImpl>, context: RenderingContext, args?: IViewArgs): VNode {
         const transform = `scale(${model.zoom}) translate(${-model.scroll.x},${-model.scroll.y})`;
         return <svg>
             <g transform={transform}>


### PR DESCRIPTION
The following changes are for consistency with the new naming scheme:
 - Renamed `ViewportRootElement` class to `ViewportRootElementImpl`
 - Renamed `ViewportRootElementSchema` interface to `ViewportRootElement` and moved to `sprotty-protocol` package.