### PR TITLE
Add request context to avoid collisions in request IDs

### DIFF
--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -56,12 +56,21 @@ export function isRequestAction(object?: Action): object is RequestAction<Respon
     return hasOwnProperty<string, string>(object, 'requestId', 'string');
 }
 
+let requestContext = '';
 let nextRequestId = 1;
 /**
  * Generate a unique `requestId` for a request action.
  */
 export function generateRequestId(): string {
-    return (nextRequestId++).toString();
+    return `${requestContext}_${nextRequestId++}`;
+}
+
+/**
+ * Configure the context in which request actions are created. This is typically either
+ * 'client' or 'server' to avoid collisions of request IDs.
+ */
+export function setRequestContext(context: string): void {
+    requestContext = context;
 }
 
 /**

--- a/packages/sprotty/src/base/actions/action-dispatcher.ts
+++ b/packages/sprotty/src/base/actions/action-dispatcher.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from 'inversify';
 import {
     Action, isAction, isRequestAction, isResponseAction, RedoAction, RejectAction, RequestAction,
-    ResponseAction, SetModelAction, UndoAction
+    ResponseAction, SetModelAction, setRequestContext, UndoAction
 } from 'sprotty-protocol/lib/actions';
 import { Deferred } from 'sprotty-protocol/lib/utils/async';
 import { TYPES } from '../types';
@@ -33,6 +33,10 @@ export interface IActionDispatcher {
     dispatchAll(actions: Action[]): Promise<void>
     request<Res extends ResponseAction>(action: RequestAction<Res>): Promise<Res>
 }
+
+// This code should be used only in the client part of a Sprotty application.
+// We set the request context to 'client' to avoid collisions with requests created by the server.
+setRequestContext('client');
 
 /**
  * Collects actions, converts them to commands and dispatches them.


### PR DESCRIPTION
Fixes #384. Requests created in the client are always prefixed with `client_`. In addition, server code can use `setRequestContext('server')` to be 100% sure.