### PR TITLE
fixed (w/h)Align center for containers with min width

### DIFF
--- a/packages/sprotty/src/features/bounds/abstract-layout.ts
+++ b/packages/sprotty/src/features/bounds/abstract-layout.ts
@@ -32,11 +32,11 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
         const childrenSize = this.getChildrenSize(container, options, layouter);
         const maxWidth = options.paddingFactor * (
             options.resizeContainer
-            ? childrenSize.width
+            ? Math.max(childrenSize.width, options.minWidth)
             : Math.max(0, this.getFixedContainerBounds(container, options, layouter).width) - options.paddingLeft - options.paddingRight);
         const maxHeight =  options.paddingFactor * (
             options.resizeContainer
-            ? childrenSize.height
+            ? Math.max(childrenSize.height, options.minHeight)
             : Math.max(0, this.getFixedContainerBounds(container, options, layouter).height) - options.paddingTop - options.paddingBottom);
         if (maxWidth > 0 && maxHeight > 0) {
             const offset = this.layoutChildren(container, layouter, options, maxWidth, maxHeight);


### PR DESCRIPTION
Fixes #106

This fixes center alignment for when the parent node or the compartments parent has a set minWidth.

**How to test:**
Take the class diagram example 
configure the first node as follows (model-source.ts:155)
```
            layout: 'vbox',
            layoutOptions: {
                minWidth: 200,
            },
            children: [
                <SCompartment>{
                    id: 'node0_header',
                    type: 'comp:header',
                    layout: 'vbox',
                    layoutOptions: {
                        hAlign: 'center',
                    },
                    children: [
                        <SLabel>{
                            id: 'node0_classname',
                            type: 'label:heading',
                            text: 'Foo'
                        },
                        <SLabel>{
                            id: 'node0_classname_2',
                            type: 'label:heading',
                            text: 's'
                        },
                    ]
```
you shouold now see both text items are aligned correctly in the center. Previous to this fix they would be aligned left even though hAlign center was set