### PR TITLE
Enables jsx tests

### DIFF
--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -32,7 +32,6 @@
     "tinyqueue": "^2.0.3"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.6",
     "@types/file-saver": "^2.0.5",
     "@types/jsdom": "^21.1.3",
     "jsdom": "^22.1.0",

--- a/packages/sprotty/src/base/views/css-class-postprocessor.spec.tsx
+++ b/packages/sprotty/src/base/views/css-class-postprocessor.spec.tsx
@@ -16,6 +16,7 @@
 
  /** @jsx svg */
 import { svg } from '../../lib/jsx';
+import 'reflect-metadata';
 
 import { expect, describe, it } from 'vitest';
 import { CssClassPostprocessor } from './css-class-postprocessor';

--- a/packages/sprotty/src/base/views/thunk-view.spec.tsx
+++ b/packages/sprotty/src/base/views/thunk-view.spec.tsx
@@ -16,8 +16,9 @@
 
  /** @jsx svg */
 import { svg } from '../../lib/jsx';
+import 'reflect-metadata';
 
-import { expect, describe, it } from 'vitest';
+import { expect, describe, beforeAll, it } from 'vitest';
 import { init } from "snabbdom";
 import { SModelElementImpl } from "../model/smodel";
 import { ModelRenderer } from './viewer';
@@ -28,7 +29,7 @@ import toHTML from 'snabbdom-to-html';
 
 describe('ThunkView', () => {
 
-    before(function () {
+    beforeAll(function () {
         setup();
     });
 

--- a/packages/sprotty/src/lib/jsx.spec.tsx
+++ b/packages/sprotty/src/lib/jsx.spec.tsx
@@ -17,8 +17,6 @@
 /** @jsx svg */
 import { svg } from './jsx';
 
-import 'mocha';
-import { expect } from 'chai';
 import { h } from 'snabbdom';
 
 const svgNS = 'http://www.w3.org/2000/svg';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
         deps: {
             interopDefault: true
         },
-        include: ['**/*.spec.ts'],
+        include: ['**/*.spec.ts', '**/*.spec.tsx'],
         globals: true,
     }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,11 +862,6 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.9.tgz#144d762491967db8c6dea38e03d2206c2623feec"
   integrity sha512-69TtiDzu0bcmKQv3yg1Zx409/Kd7r0b5F1PfpYJfSHzLGtB53547V4u+9iqKYsTu/O2ai6KTb0TInNpvuQ3qmg==
 
-"@types/chai@^4.3.6":
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.6.tgz#7b489e8baf393d5dd1266fb203ddd4ea941259e6"
-  integrity sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==
-
 "@types/connect@*":
   version "3.4.36"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.36.tgz#e511558c15a39cb29bd5357eebb57bd1459cd1ab"


### PR DESCRIPTION
Enables jsx tests again. Also removed dev dependency to `@types/chai`.

To test run all Vitest tests:
- Tests before: 198
- Tests after: 210