### PR TITLE
Replace rimraf with shx

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "prepare": "yarn run build",
-    "build": "webpack && tsc",
+    "compile": "tsc -b tsconfig.json",
+    "build": "webpack && npm run compile",
     "watch": "yarn run watch:browser",
     "watch:browser": "webpack --watch",
     "watch:server": "tsc -w",

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -5,6 +5,7 @@
       "reflect-metadata",
       "webpack-env"
     ],
+    "composite": false,
     "declaration": false,
     "declarationMap": false
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "eslint-plugin-no-null": "^1.0.2",
     "lerna": "^7.3.0",
     "reflect-metadata": "^0.1.13",
-    "rimraf": "^5.0.5",
     "semver": "^7.5.4",
+    "shx": "^0.3.4",
     "typescript": "~5.2.2",
     "@vitest/coverage-v8": "~0.34.6",
     "vitest": "~0.34.6"

--- a/packages/generator-sprotty/package.json
+++ b/packages/generator-sprotty/package.json
@@ -39,8 +39,11 @@
     },
     "scripts": {
         "clean": "shx rm -fr app *.tsbuildinfo",
+        "build": "tsc",
+        "watch": "tsc --watch",
         "run": "yo sprotty",
-        "debug": "npx --node-arg=--inspect yo sprotty"
+        "debug": "npx --node-arg=--inspect yo sprotty",
+        "test": "echo \"No tests defined.\""
     },
     "files": [
         "app",

--- a/packages/generator-sprotty/package.json
+++ b/packages/generator-sprotty/package.json
@@ -38,7 +38,7 @@
         "yeoman-test": "^7.4.0"
     },
     "scripts": {
-        "clean": "rimraf app",
+        "clean": "shx rm -fr app",
         "build": "tsc --skipLibCheck",
         "watch": "tsc --watch --skipLibCheck",
         "run": "yo sprotty",

--- a/packages/generator-sprotty/package.json
+++ b/packages/generator-sprotty/package.json
@@ -38,12 +38,9 @@
         "yeoman-test": "^7.4.0"
     },
     "scripts": {
-        "clean": "shx rm -fr app",
-        "build": "tsc --skipLibCheck",
-        "watch": "tsc --watch --skipLibCheck",
+        "clean": "shx rm -fr app *.tsbuildinfo",
         "run": "yo sprotty",
-        "debug": "npx --node-arg=--inspect yo sprotty",
-        "test": "echo \"No tests defined.\""
+        "debug": "npx --node-arg=--inspect yo sprotty"
     },
     "files": [
         "app",

--- a/packages/generator-sprotty/tsconfig.json
+++ b/packages/generator-sprotty/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "app",
-    "composite": true
+    "outDir": "app"
   },
   "include": [
       "src"

--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -28,7 +28,10 @@
     "inversify": "^6.0.1"
   },
   "scripts": {
-    "clean": "shx rm -fr lib artifacts *.tsbuildinfo"
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "test": "vitest run --config ../../vite.config.ts"
   },
   "files": [
     "lib",

--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -28,10 +28,7 @@
     "inversify": "^6.0.1"
   },
   "scripts": {
-    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
-    "build": "tsc -p ./tsconfig.json",
-    "test": "vitest run --config ../../vite.config.ts",
-    "watch": "tsc -w -p ./tsconfig.json"
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo"
   },
   "files": [
     "lib",

--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -28,7 +28,7 @@
     "inversify": "^6.0.1"
   },
   "scripts": {
-    "clean": "rimraf lib artifacts tsconfig.tsbuildinfo",
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
     "build": "tsc -p ./tsconfig.json",
     "test": "vitest run --config ../../vite.config.ts",
     "watch": "tsc -w -p ./tsconfig.json"

--- a/packages/sprotty-elk/tsconfig.json
+++ b/packages/sprotty-elk/tsconfig.json
@@ -5,8 +5,7 @@
     "outDir": "lib",
     "types": [
       "node"
-    ],
-  "composite": true
+    ]
   },
   "include": [
     "src"

--- a/packages/sprotty-protocol/package.json
+++ b/packages/sprotty-protocol/package.json
@@ -23,7 +23,10 @@
   },
 
   "scripts": {
-    "clean": "shx rm -fr lib artifacts *.tsbuildinfo"
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "test": "vitest run --config ../../vite.config.ts"
   },
   "files": [
     "lib",

--- a/packages/sprotty-protocol/package.json
+++ b/packages/sprotty-protocol/package.json
@@ -23,10 +23,7 @@
   },
 
   "scripts": {
-    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
-    "build": "tsc -p ./tsconfig.json",
-    "test": "vitest run --config ../../vite.config.ts",
-    "watch": "tsc -w -p ./tsconfig.json"
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo"
   },
   "files": [
     "lib",

--- a/packages/sprotty-protocol/package.json
+++ b/packages/sprotty-protocol/package.json
@@ -23,7 +23,7 @@
   },
 
   "scripts": {
-    "clean": "rimraf lib artifacts tsconfig.tsbuildinfo",
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
     "build": "tsc -p ./tsconfig.json",
     "test": "vitest run --config ../../vite.config.ts",
     "watch": "tsc -w -p ./tsconfig.json"

--- a/packages/sprotty-protocol/tsconfig.json
+++ b/packages/sprotty-protocol/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
-    "composite": true
+    "outDir": "lib"
   },
   "include": [
     "src"

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -37,10 +37,7 @@
     "snabbdom-to-html": "^7.1.0"
   },
   "scripts": {
-    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
-    "build": "tsc -p ./tsconfig.json",
-    "test": "vitest run --config ../../vite.config.ts",
-    "watch": "tsc -w -p ./tsconfig.json"
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo"
   },
   "files": [
     "lib",

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -37,7 +37,7 @@
     "snabbdom-to-html": "^7.1.0"
   },
   "scripts": {
-    "clean": "rimraf lib artifacts tsconfig.tsbuildinfo",
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
     "build": "tsc -p ./tsconfig.json",
     "test": "vitest run --config ../../vite.config.ts",
     "watch": "tsc -w -p ./tsconfig.json"

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -37,7 +37,10 @@
     "snabbdom-to-html": "^7.1.0"
   },
   "scripts": {
-    "clean": "shx rm -fr lib artifacts *.tsbuildinfo"
+    "clean": "shx rm -fr lib artifacts *.tsbuildinfo",
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "test": "vitest run --config ../../vite.config.ts"
   },
   "files": [
     "lib",

--- a/packages/sprotty/tsconfig.json
+++ b/packages/sprotty/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
-    "composite": true
+    "outDir": "lib"
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
         "esModuleInterop": true,
-        "jsx": "react"
+        "jsx": "react",
+        "composite": true
     },
     "include": [
         "**/src/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,7 +3138,7 @@ glob@7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.2.2, glob@^10.3.7:
+glob@^10.2.2:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
   integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
@@ -4269,7 +4269,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -5403,13 +5403,6 @@ rimraf@^4.4.1:
   dependencies:
     glob "^9.2.0"
 
-rimraf@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.5.tgz#9be65d2d6e683447d2e9013da2bf451139a61ccf"
-  integrity sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==
-  dependencies:
-    glob "^10.3.7"
-
 rollup@^3.27.1:
   version "3.29.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
@@ -5564,6 +5557,14 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shx@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
+  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.5"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
`shx` is the command-line util of `shelljs` which is already a dependency of `yeoman-generator`
I just realized `rimraf` was updated again after a long pause. Now `shelljs` is moving slow, but there still seems to be activity.