### PR TITLE
Move edge labels

### DIFF
--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -21,7 +21,7 @@ import {
     SRoutingHandleView, PreRenderedElementImpl, HtmlRootImpl, SGraphImpl, configureModelElement, SLabelImpl,
     SCompartmentImpl, SEdgeImpl, SButtonImpl, SRoutingHandleImpl, RevealNamedElementActionProvider,
     CenterGridSnapper, expandFeature, nameFeature, withEditLabelFeature, editLabelFeature,
-    RectangularNode, BezierCurveEdgeView, SBezierCreateHandleView, SBezierControlHandleView
+    RectangularNode, BezierCurveEdgeView, SBezierCreateHandleView, SBezierControlHandleView, moveFeature, selectFeature
 } from 'sprotty';
 import edgeIntersectionModule from 'sprotty/lib/features/edge-intersection/di.config';
 import { BezierMouseListener } from 'sprotty/lib/features/routing/bezier-edge-router';
@@ -63,7 +63,7 @@ export default (containerId: string) => {
             enable: [editLabelFeature]
         });
         configureModelElement(context, 'label:text', PropertyLabel, SLabelView, {
-            enable: [editLabelFeature]
+            enable: [moveFeature, selectFeature]
         });
         configureModelElement(context, 'comp:comp', SCompartmentImpl, SCompartmentView);
         configureModelElement(context, 'comp:header', SCompartmentImpl, SCompartmentView);

--- a/examples/classdiagram/src/model-source.ts
+++ b/examples/classdiagram/src/model-source.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { ActionHandlerRegistry, LocalModelSource, Expandable } from 'sprotty';
+import { ActionHandlerRegistry, LocalModelSource, Expandable, EdgeLayoutable } from 'sprotty';
 import {
     Action, CollapseExpandAction, CollapseExpandAllAction, SCompartment, SEdge, SGraph, SLabel,
     SModelElement, SModelIndex, SModelRoot, SNode
@@ -400,14 +400,15 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         rotate: false
                     }
                 },
-                <SLabel> {
+                <SLabel & EdgeLayoutable> {
                     id: 'edge0_label_right',
                     type: 'label:text',
                     text: 'right',
                     edgePlacement:  {
                         position: 0.7,
                         side: 'right',
-                        rotate: false
+                        rotate: false,
+                        moveMode: 'edge' // optional, because it's the default anyway
                     }
                 }
             ]
@@ -456,13 +457,15 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         side: 'left'
                     }
                 },
-                <SLabel> {
+                <SLabel & EdgeLayoutable> {
                     id: 'edge1_label_right',
                     type: 'label:text',
                     text: 'right',
                     edgePlacement:  {
                         position: 1,
-                        side: 'right'
+                        rotate: true,
+                        side: 'right',
+                        moveMode: 'edge'
                     }
                 }
             ]
@@ -480,7 +483,49 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 { x: 390, y: 120 },
                 { x: 450, y: 40 }
             ],
-            children: []
+            children: [
+                <SLabel & EdgeLayoutable> {
+                    id: 'edge2_label_free1',
+                    type: 'label:text',
+                    text: 'free1',
+                    edgePlacement:  {
+                        position: 0.9,
+                        offset: 10,
+                        side: 'top',
+                        rotate: false,
+                        moveMode: 'free'
+                    }
+                },
+                <SLabel & EdgeLayoutable> {
+                    id: 'edge2_label_edge',
+                    type: 'label:text',
+                    text: 'edge',
+                    edgePlacement:  {
+                        position: 0.2,
+                        offset: 0,
+                        side: 'right',
+                        rotate: true,
+                        moveMode: 'edge'
+                    }
+                },
+                <SLabel & EdgeLayoutable> {
+                    id: 'edge2_label_fix',
+                    type: 'label:text',
+                    text: 'fix',
+                    edgePlacement:  {
+                        position: 0.3,
+                        offset: 10,
+                        side: 'left',
+                        rotate: true,
+                        moveMode: 'none'
+                    }
+                },
+                <SLabel> {
+                    id: 'edge2_label_free2',
+                    type: 'label:text',
+                    text: 'free2'
+                }
+            ]
         } as SEdge;
         const graph: SGraph = {
             id: 'graph',

--- a/packages/sprotty-protocol/src/model.ts
+++ b/packages/sprotty-protocol/src/model.ts
@@ -207,3 +207,45 @@ export interface ForeignObjectElement extends ShapedPreRenderedElement {
     /** The namespace to be assigned to the elements inside of the `foreignObject`. */
     namespace: string
 }
+
+/**
+ * Feature extension interface for {@link edgeLayoutFeature}.
+ */
+export interface EdgeLayoutable {
+    edgePlacement: EdgePlacement
+}
+
+export type EdgeSide = 'left' | 'right' | 'top' | 'bottom' | 'on';
+
+/**
+ * Each label attached to an edge can be placed on the edge in different ways.
+ * With this interface the placement of such a single label is defined.
+ */
+export interface EdgePlacement {
+    /**
+     * true, if the label should be rotated to touch the edge tangentially
+     */
+    rotate: boolean;
+
+    /**
+     * where is the label relative to the line's direction
+     */
+    side: EdgeSide;
+
+    /**
+     * between 0 (source anchor) and 1 (target anchor)
+     */
+    position: number;
+
+    /**
+     * space between label and edge/connected nodes
+     */
+    offset: number;
+
+    /**
+     * where should the label be moved when move feature is enabled.
+     * 'edge' means the label is moved along the edge, 'free' means the label is moved freely, 'none' means the label can not be moved.
+     * Default is 'edge'.
+     */
+    moveMode?: 'edge' | 'free' | 'none';
+}

--- a/packages/sprotty-protocol/src/utils/geometry.ts
+++ b/packages/sprotty-protocol/src/utils/geometry.ts
@@ -150,6 +150,16 @@ export namespace Point {
     export function maxDistance(a: Point, b: Point): number {
         return Math.max(Math.abs(b.x - a.x), Math.abs(b.y - a.y));
     }
+
+    /**
+     * Returns the dot product of two points.
+     * @param {Point} a - First point
+     * @param {Point} b - Second point
+     * @returns {number} The dot product
+     */
+    export function dotProduct(a: Point, b: Point): number {
+        return a.x * b.x + a.y * b.y;
+    }
 }
 
 /**

--- a/packages/sprotty/src/features/edge-layout/model.ts
+++ b/packages/sprotty/src/features/edge-layout/model.ts
@@ -21,6 +21,7 @@ import { SRoutableElementImpl } from '../routing/model';
 export const edgeLayoutFeature = Symbol('edgeLayout');
 
 /**
+ * @deprecated Use EdgeLayoutable from sprotty-protocol instead
  * Feature extension interface for {@link edgeLayoutFeature}.
  */
 export interface EdgeLayoutable {
@@ -30,17 +31,22 @@ export interface EdgeLayoutable {
 export function isEdgeLayoutable<T extends SModelElementImpl>(element: T): element is T & SChildElementImpl & BoundsAware & EdgeLayoutable {
     return element instanceof SChildElementImpl
         && element.parent instanceof SRoutableElementImpl
-        && checkEdgeLayoutable(element)
         && isBoundsAware(element)
         && element.hasFeature(edgeLayoutFeature);
 }
 
-function checkEdgeLayoutable(element: SChildElementImpl): element is SChildElementImpl & EdgeLayoutable {
+export function checkEdgePlacement(element: SChildElementImpl): element is SChildElementImpl & EdgeLayoutable {
     return 'edgePlacement' in element;
 }
 
+/**
+ * @deprecated Use EdgeSide from sprotty-protocol instead
+ */
 export type EdgeSide = 'left' | 'right' | 'top' | 'bottom' | 'on';
 
+/**
+ * @deprecated Use EdgePlacement from sprotty-protocol instead
+ */
 export class EdgePlacement extends Object {
     /**
      * true, if the label should be rotated to touch the edge tangentially
@@ -61,11 +67,20 @@ export class EdgePlacement extends Object {
      * space between label and edge/connected nodes
      */
     offset: number;
+
+    /**
+     * where should the label be moved when move feature is enabled.
+     * 'edge' means the label is moved along the edge, 'free' means the label is moved freely, 'none' means the label is not moved.
+     * Default is 'edge'.
+     */
+    moveMode?: 'edge' | 'free' | 'none';
+
 }
 
 export const DEFAULT_EDGE_PLACEMENT: EdgePlacement = {
     rotate: true,
     side: 'top',
     position: 0.5,
-    offset: 7
+    offset: 7,
+    moveMode: 'edge'
 };

--- a/packages/sprotty/src/features/routing/routing.ts
+++ b/packages/sprotty/src/features/routing/routing.ts
@@ -72,6 +72,15 @@ export interface IEdgeRouter {
     route(edge: SRoutableElementImpl): RoutedPoint[]
 
     /**
+     * Finds the orthogonal intersection point between an edge and a given point in 2D space.
+     *
+     * @param edge - The edge to find the intersection point on.
+     * @param point - The point to find the intersection with.
+     * @returns The intersection point and its derivative on the respective edge segment.
+     */
+    findOrthogonalIntersection(edge: SRoutableElementImpl, point: Point): {point: Point, derivative: Point} | undefined
+
+    /**
      * Calculates a point on the edge
      *
      * @param t a value between 0 (sourceAnchor) and 1 (targetAnchor)


### PR DESCRIPTION
This PR introduces a new configuration option for enhanced label positioning related to edges. It adds the possibility to move labels along the edge or completely free. Or set the moveMode to none to not move a certain label at all.

The move feature must be enabled in the di config for make label placement work.
For type-safe edge placement, the corresponding element type in the sprotty model must be extended with EdgeLayoutable type.
If edgePlacement is not specified, the label is placed at default position, with the exception that labels can be freely moved.
When edgePlacement is configured and moveMode is set to 'none', labels will not be moveable.
If edgePlacement is set and moveMode is 'edge', labels are constrained to movement along the associated edge. This also serves as the default behavior when moveMode is undefined.
When edgePlacement is configured and moveMode is 'free', labels can be moved freely in any direction.