### PR TITLE
Add condition to logger

### DIFF
--- a/packages/sprotty/src/model-source/logging.ts
+++ b/packages/sprotty/src/model-source/logging.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject } from 'inversify';
 import { LoggingAction } from 'sprotty-protocol/lib/actions';
-import { ILogger, LogLevel } from '../utils/logging';
+import { ILogger, LogLevel, NullLogger } from '../utils/logging';
 import { TYPES } from '../base/types';
 import { ModelSource } from './model-source';
 
@@ -28,6 +28,13 @@ export class ForwardingLogger implements ILogger {
 
     @inject(TYPES.ModelSourceProvider) protected modelSourceProvider: () => Promise<ModelSource>;
     @inject(TYPES.LogLevel) public logLevel: LogLevel;
+
+    condition(condition: boolean): ILogger {
+        if (condition)
+            return this;
+        else
+            return new NullLogger();
+    }
 
     error(thisArg: any, message: string, ...params: any[]): void {
         if (this.logLevel >= LogLevel.error)

--- a/packages/sprotty/src/utils/logging.ts
+++ b/packages/sprotty/src/utils/logging.ts
@@ -21,6 +21,8 @@ import { ViewerOptions } from "../base/views/viewer-options";
 export interface ILogger {
     logLevel: LogLevel
 
+    condition(condition: boolean): ILogger
+
     error(thisArg: any, message: string, ...params: any[]): void
     warn(thisArg: any, message: string, ...params: any[]): void
     info(thisArg: any, message: string, ...params: any[]): void
@@ -33,6 +35,10 @@ export enum LogLevel { none = 0, error = 1, warn = 2, info = 3, log = 4 }
 export class NullLogger implements ILogger {
     logLevel: LogLevel = LogLevel.none;
 
+    condition(condition: boolean): ILogger {
+        return this;
+    }
+
     error(thisArg: any, message: string, ...params: any[]): void {}
     warn(thisArg: any, message: string, ...params: any[]): void {}
     info(thisArg: any, message: string, ...params: any[]): void {}
@@ -44,6 +50,13 @@ export class ConsoleLogger implements ILogger {
 
     @inject(TYPES.LogLevel) public logLevel: LogLevel = LogLevel.log;
     @inject(TYPES.ViewerOptions) protected viewOptions: ViewerOptions = { baseDiv: '' } as ViewerOptions;
+
+    condition(condition: boolean): ILogger {
+        if (condition)
+            return this;
+        else
+            return new NullLogger();
+    }
 
     error(thisArg: any, message: string, ...params: any[]): void {
         if (this.logLevel >= LogLevel.error)


### PR DESCRIPTION
Sometimes (especially while development) it is useful to only log under certain conditions. This small enhancement enables to write such conditional logs like this instead of if blocks and console.log:
`this.logger.condition(edge.id === 'edge1').log(this, 'Edge Bounds are: ', edge.bounds);`