### PR TITLE
Moved feature interfaces to sprotty-protocol

### DIFF
--- a/examples/classdiagram/src/model-source.ts
+++ b/examples/classdiagram/src/model-source.ts
@@ -15,10 +15,10 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { ActionHandlerRegistry, LocalModelSource, Expandable, EdgeLayoutable } from 'sprotty';
+import { ActionHandlerRegistry, LocalModelSource } from 'sprotty';
 import {
     Action, CollapseExpandAction, CollapseExpandAllAction, SCompartment, SEdge, SGraph, SLabel,
-    SModelElement, SModelIndex, SModelRoot, SNode
+    SModelElement, SModelIndex, SModelRoot, SNode, Expandable, EdgeLayoutable
 } from 'sprotty-protocol';
 
 @injectable()

--- a/examples/classdiagram/src/model.ts
+++ b/examples/classdiagram/src/model.ts
@@ -15,9 +15,10 @@
  ********************************************************************************/
 
 import {
-    SShapeElementImpl, Expandable, RectangularNode, Nameable, SLabelImpl, WithEditableLabel, isEditableLabel,
+    SShapeElementImpl, RectangularNode, Nameable, SLabelImpl, WithEditableLabel, isEditableLabel,
     boundsFeature, layoutContainerFeature, layoutableChildFeature, fadeFeature
 } from 'sprotty';
+import { Expandable } from 'sprotty-protocol';
 
 export class ClassNode extends RectangularNode implements Expandable, Nameable, WithEditableLabel {
     expanded: boolean = false;

--- a/examples/multicore/src/chipmodel.ts
+++ b/examples/multicore/src/chipmodel.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import {
-    SShapeElementImpl, SChildElementImpl, BoundsAware, boundsFeature, fadeFeature,
-    layoutContainerFeature, LayoutContainer, selectFeature, ViewportRootElementImpl,
+    SShapeElementImpl, SChildElementImpl, InternalBoundsAware, boundsFeature, fadeFeature,
+    layoutContainerFeature, selectFeature, ViewportRootElementImpl, InternalLayoutContainer,
     hoverFeedbackFeature, popupFeature
 } from 'sprotty';
 import {
@@ -33,7 +33,7 @@ export interface ProcessorSchema extends SModelRoot {
     columns: number
 }
 
-export class Processor extends ViewportRootElementImpl implements BoundsAware {
+export class Processor extends ViewportRootElementImpl implements InternalBoundsAware {
     static override readonly DEFAULT_FEATURES = [...ViewportRootElementImpl.DEFAULT_FEATURES, boundsFeature];
 
     rows: number = 0;
@@ -64,7 +64,7 @@ export interface CoreSchema extends SShapeElement {
     children: SModelElement[]
 }
 
-export class Core extends SShapeElementImpl implements Selectable, Fadeable, Hoverable, LayoutContainer {
+export class Core extends SShapeElementImpl implements Selectable, Fadeable, Hoverable, InternalLayoutContainer {
     static readonly DEFAULT_FEATURES = [selectFeature, fadeFeature, layoutContainerFeature,
         hoverFeedbackFeature, popupFeature];
 

--- a/examples/multicore/src/chipmodel.ts
+++ b/examples/multicore/src/chipmodel.ts
@@ -15,11 +15,13 @@
  ********************************************************************************/
 
 import {
-    SShapeElementImpl, SChildElementImpl, BoundsAware, boundsFeature, Fadeable, fadeFeature,
-    layoutContainerFeature, LayoutContainer, Selectable, selectFeature,
-    ViewportRootElementImpl, hoverFeedbackFeature, Hoverable, popupFeature
+    SShapeElementImpl, SChildElementImpl, BoundsAware, boundsFeature, fadeFeature,
+    layoutContainerFeature, LayoutContainer, selectFeature, ViewportRootElementImpl,
+    hoverFeedbackFeature, popupFeature
 } from 'sprotty';
-import { Bounds, SModelElement, SModelRoot, JsonMap, SShapeElement } from 'sprotty-protocol';
+import {
+    Bounds, SModelElement, SModelRoot, JsonMap, SShapeElement, Selectable, Hoverable, Fadeable
+} from 'sprotty-protocol';
 
 export enum Direction { up, down, left, right }
 

--- a/examples/svg/src/standalone.ts
+++ b/examples/svg/src/standalone.ts
@@ -14,9 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { TYPES, Projectable, LocalModelSource } from 'sprotty';
+import { TYPES, LocalModelSource } from 'sprotty';
 import createContainer from './di.config';
-import { ForeignObjectElement, SShapeElement, ShapedPreRenderedElement, ViewportRootElement } from 'sprotty-protocol';
+import {
+    ForeignObjectElement, SShapeElement, ShapedPreRenderedElement, ViewportRootElement, Projectable
+} from 'sprotty-protocol';
 
 function loadFile(path: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {

--- a/packages/sprotty-protocol/src/model.ts
+++ b/packages/sprotty-protocol/src/model.ts
@@ -45,22 +45,14 @@ export interface ViewportRootElement extends SModelRoot, Partial<Viewport>, Part
 /**
  * Root element for graph-like models.
  */
-export interface SGraph extends ViewportRootElement {
+export interface SGraph extends ViewportRootElement, Partial<LayoutableChild> {
     children: SModelElement[]
-    layoutOptions?: ModelLayoutOptions
 
     /** @deprecated Use `position` and `size` instead. */
     bounds?: Bounds
 }
 
-/**
- * Options to control the "micro layout" of a model element, i.e. the arrangement of its content
- * using simple algorithms such as horizontal or vertical box layout.
- */
-export type ModelLayoutOptions = { [key: string]: string | number | boolean };
-
-export interface SShapeElement extends SModelElement, Partial<BoundsAware> {
-    layoutOptions?: ModelLayoutOptions
+export interface SShapeElement extends SModelElement, Partial<LayoutableChild> {
 }
 
 /**
@@ -68,8 +60,7 @@ export interface SShapeElement extends SModelElement, Partial<BoundsAware> {
  * another node via an SEdge. Such a connection can be direct, i.e. the node is the source or target of
  * the edge, or indirect through a port, i.e. it contains an SPort which is the source or target of the edge.
  */
-export interface SNode extends SShapeElement, Partial<Selectable>, Partial<Hoverable>, Partial<Fadeable> {
-    layout?: string
+export interface SNode extends SShapeElement, Partial<LayoutContainer>, Partial<Selectable>, Partial<Hoverable>, Partial<Fadeable> {
     anchorKind?: string
 }
 
@@ -102,8 +93,7 @@ export interface SLabel extends SShapeElement, Partial<Selectable>, Partial<Alig
  * A compartment is used to group multiple child elements such as labels of a node. Usually a `vbox`
  * or `hbox` layout is used to arrange these children.
  */
-export interface SCompartment extends SShapeElement {
-    layout?: string
+export interface SCompartment extends SShapeElement, Partial<LayoutContainer> {
 }
 
 /**
@@ -138,11 +128,35 @@ export function isZoomable(element: SModelElement | Zoomable): element is Zoomab
 }
 
 /**
+ * An element that can be placed at a specific location using its position property.
+ * Feature extension interface for `moveFeature`.
+ */
+export interface Locateable {
+    position: Point
+}
+
+/**
  * Model elements that implement this interface have a position and a size.
  */
-export interface BoundsAware {
-    position: Point
+export interface BoundsAware extends Locateable {
     size: Dimension
+}
+
+export type ModelLayoutOptions = { [key: string]: string | number | boolean };
+
+/**
+ * Feature extension interface for `layoutableChildFeature`. This is used when the parent
+ * element has a `layout` property (meaning it's a `LayoutContainer`).
+ */
+export interface LayoutableChild extends BoundsAware {
+    layoutOptions?: ModelLayoutOptions
+}
+
+/**
+ * Used to identify model elements that specify a layout to apply to their children.
+ */
+export interface LayoutContainer extends LayoutableChild {
+    layout: string
 }
 
 /**

--- a/packages/sprotty-protocol/src/model.ts
+++ b/packages/sprotty-protocol/src/model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 TypeFox and others.
+ * Copyright (c) 2021-2023 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,19 +37,73 @@ export interface SModelRoot extends SModelElement {
 }
 
 /**
- * Model elements that implement this interface have a position and a size.
+ * Usually the root of a model is also a viewport.
  */
-export interface BoundsAware {
-    position: Point
-    size: Dimension
+export interface ViewportRootElement extends SModelRoot, Partial<Viewport>, Partial<BoundsAware> {
 }
 
 /**
- * Used to adjust elements whose bounding box is not at the origin, e.g. labels
- * or pre-rendered SVG figures.
+ * Root element for graph-like models.
  */
-export interface Alignable {
-    alignment: Point
+export interface SGraph extends ViewportRootElement {
+    children: SModelElement[]
+    layoutOptions?: ModelLayoutOptions
+
+    /** @deprecated Use `position` and `size` instead. */
+    bounds?: Bounds
+}
+
+/**
+ * Options to control the "micro layout" of a model element, i.e. the arrangement of its content
+ * using simple algorithms such as horizontal or vertical box layout.
+ */
+export type ModelLayoutOptions = { [key: string]: string | number | boolean };
+
+export interface SShapeElement extends SModelElement, Partial<BoundsAware> {
+    layoutOptions?: ModelLayoutOptions
+}
+
+/**
+ * Model element class for nodes, which are the main entities in a graph. A node can be connected to
+ * another node via an SEdge. Such a connection can be direct, i.e. the node is the source or target of
+ * the edge, or indirect through a port, i.e. it contains an SPort which is the source or target of the edge.
+ */
+export interface SNode extends SShapeElement, Partial<Selectable>, Partial<Hoverable>, Partial<Fadeable> {
+    layout?: string
+    anchorKind?: string
+}
+
+/**
+ * A port is a connection point for edges. It should always be contained in an SNode.
+ */
+export interface SPort extends SShapeElement, Partial<Selectable>, Partial<Hoverable>, Partial<Fadeable> {
+    anchorKind?: string
+}
+
+/**
+ * Model element class for edges, which are the connectors in a graph. An edge has a source and a target,
+ * each of which can be either a node or a port. The source and target elements are referenced via their ids.
+ */
+export interface SEdge extends SModelElement, Partial<Selectable>, Partial<Hoverable>, Partial<Fadeable> {
+    sourceId: string
+    targetId: string
+    routerKind?: string
+    routingPoints?: Point[]
+}
+
+/**
+ * A label can be attached to a node, edge, or port, and contains some text to be rendered in its view.
+ */
+export interface SLabel extends SShapeElement, Partial<Selectable>, Partial<Alignable> {
+    text: string
+}
+
+/**
+ * A compartment is used to group multiple child elements such as labels of a node. Usually a `vbox`
+ * or `hbox` layout is used to arrange these children.
+ */
+export interface SCompartment extends SShapeElement {
+    layout?: string
 }
 
 /**
@@ -57,16 +111,6 @@ export interface Alignable {
  * applied to the root element to enable navigating through the diagram.
  */
 export interface Viewport extends Scrollable, Zoomable {
-}
-
-/**
- * Usually the root of a model is also a viewport.
- */
-export interface ViewportRootElement extends SModelRoot {
-    scroll?: Point
-    zoom?: number
-    position?: Point
-    size?: Dimension
 }
 
 /**
@@ -94,79 +138,127 @@ export function isZoomable(element: SModelElement | Zoomable): element is Zoomab
 }
 
 /**
- * Root element for graph-like models.
+ * Model elements that implement this interface have a position and a size.
  */
-export interface SGraph extends SModelRoot {
-    children: SModelElement[]
-    bounds?: Bounds
-    scroll?: Point
-    zoom?: number
-    layoutOptions?: ModelLayoutOptions
+export interface BoundsAware {
+    position: Point
+    size: Dimension
 }
 
 /**
- * Options to control the "micro layout" of a model element, i.e. the arrangement of its content
- * using simple algorithms such as horizontal or vertical box layout.
+ * Feature extension interface for `alignFeature`.
+ * Used to adjust elements whose bounding box is not at the origin, e.g. labels
+ * or pre-rendered SVG figures.
  */
-export type ModelLayoutOptions = { [key: string]: string | number | boolean };
-
-export interface SShapeElement extends SModelElement {
-    position?: Point
-    size?: Dimension
-    layoutOptions?: ModelLayoutOptions
+export interface Alignable {
+    alignment: Point
 }
 
 /**
- * Model element class for nodes, which are the main entities in a graph. A node can be connected to
- * another node via an SEdge. Such a connection can be direct, i.e. the node is the source or target of
- * the edge, or indirect through a port, i.e. it contains an SPort which is the source or target of the edge.
+ * Feature extension interface for `selectFeature`. The selection status is often considered
+ * in the frontend views, e.g. by switching CSS classes.
  */
-export interface SNode extends SShapeElement {
-    layout?: string
-    selected?: boolean
-    hoverFeedback?: boolean
-    opacity?: number
-    anchorKind?: string
+export interface Selectable {
+    selected: boolean
 }
 
 /**
- * A port is a connection point for edges. It should always be contained in an SNode.
+ * Feature extension interface for `hoverFeedbackFeature`. The hover feedback status is often
+ * considered in the frontend views, e.g. by switching CSS classes.
  */
-export interface SPort extends SShapeElement {
-    selected?: boolean
-    hoverFeedback?: boolean
-    opacity?: number
-    anchorKind?: string
+export interface Hoverable {
+    hoverFeedback: boolean
 }
 
 /**
- * Model element class for edges, which are the connectors in a graph. An edge has a source and a target,
- * each of which can be either a node or a port. The source and target elements are referenced via their ids.
+ * Feature extension interface for `fadeFeature`. Fading is mostly used to animate when an element
+ * appears or disappears.
  */
-export interface SEdge extends SModelElement {
-    sourceId: string
-    targetId: string
-    routerKind?: string
-    routingPoints?: Point[]
-    selected?: boolean
-    hoverFeedback?: boolean
-    opacity?: number
+export interface Fadeable {
+    opacity: number
 }
 
 /**
- * A label can be attached to a node, edge, or port, and contains some text to be rendered in its view.
+ * Feature extension interface for `expandFeature`.
+ * Model elements that implement this interface can be expanded and collapsed.
  */
-export interface SLabel extends SShapeElement {
-    text: string
-    selected?: boolean
+export interface Expandable {
+    expanded: boolean
 }
 
 /**
- * A compartment is used to group multiple child elements such as labels of a node. Usually a `vbox`
- * or `hbox` layout is used to arrange these children.
+ * Model elements implementing this interface can be displayed on a projection bar.
+ * _Note:_ If set, the projectedBounds property will be prefered over the model element bounds.
+ * Otherwise model elements also have to be `BoundsAware` so their projections can be shown.
  */
-export interface SCompartment extends SShapeElement {
-    layout?: string
+export interface Projectable {
+    projectionCssClasses: string[],
+    projectedBounds?: Bounds,
+}
+
+/**
+ * Feature extension interface for `edgeLayoutFeature`. This is often applied to
+ * {@link SLabel} elements to specify their placement along the containing edge.
+ */
+export interface EdgeLayoutable {
+    edgePlacement: EdgePlacement
+}
+
+export type EdgeSide = 'left' | 'right' | 'top' | 'bottom' | 'on';
+
+/**
+ * Each label attached to an edge can be placed on the edge in different ways.
+ * With this interface the placement of such a single label is defined.
+ */
+export interface EdgePlacement {
+    /**
+     * true, if the label should be rotated to touch the edge tangentially
+     */
+    rotate: boolean;
+
+    /**
+     * where is the label relative to the line's direction
+     */
+    side: EdgeSide;
+
+    /**
+     * between 0 (source anchor) and 1 (target anchor)
+     */
+    position: number;
+
+    /**
+     * space between label and edge/connected nodes
+     */
+    offset: number;
+
+    /**
+     * where should the label be moved when move feature is enabled.
+     * 'edge' means the label is moved along the edge, 'free' means the label is moved freely, 'none' means the label can not be moved.
+     * Default is 'edge'.
+     */
+    moveMode?: 'edge' | 'free' | 'none';
+}
+
+/**
+ * Buttons are elements that can react to clicks. A button handler can be registered in the frontend.
+ */
+export interface SButton extends SShapeElement {
+    pressed: boolean
+    enabled: boolean
+}
+
+/**
+ * An issue marker is used to display a symbol about an error or a warning attached to another model element.
+ */
+export interface SIssueMarker extends SShapeElement {
+    issues: SIssue[]
+}
+
+export type SIssueSeverity = 'error' | 'warning' | 'info';
+
+export interface SIssue {
+    message: string
+    severity: SIssueSeverity
 }
 
 /**
@@ -206,46 +298,4 @@ export interface ShapedPreRenderedElement extends PreRenderedElement {
 export interface ForeignObjectElement extends ShapedPreRenderedElement {
     /** The namespace to be assigned to the elements inside of the `foreignObject`. */
     namespace: string
-}
-
-/**
- * Feature extension interface for {@link edgeLayoutFeature}.
- */
-export interface EdgeLayoutable {
-    edgePlacement: EdgePlacement
-}
-
-export type EdgeSide = 'left' | 'right' | 'top' | 'bottom' | 'on';
-
-/**
- * Each label attached to an edge can be placed on the edge in different ways.
- * With this interface the placement of such a single label is defined.
- */
-export interface EdgePlacement {
-    /**
-     * true, if the label should be rotated to touch the edge tangentially
-     */
-    rotate: boolean;
-
-    /**
-     * where is the label relative to the line's direction
-     */
-    side: EdgeSide;
-
-    /**
-     * between 0 (source anchor) and 1 (target anchor)
-     */
-    position: number;
-
-    /**
-     * space between label and edge/connected nodes
-     */
-    offset: number;
-
-    /**
-     * where should the label be moved when move feature is enabled.
-     * 'edge' means the label is moved along the edge, 'free' means the label is moved freely, 'none' means the label can not be moved.
-     * Default is 'edge'.
-     */
-    moveMode?: 'edge' | 'free' | 'none';
 }

--- a/packages/sprotty/src/base/model/smodel-factory.spec.ts
+++ b/packages/sprotty/src/base/model/smodel-factory.spec.ts
@@ -17,13 +17,14 @@
 import 'reflect-metadata';
 import { expect, describe, it } from 'vitest';
 import { Container } from 'inversify';
+import { Selectable } from 'sprotty-protocol/lib/model';
 import { TYPES } from '../types';
 import { ModelIndexImpl, SChildElementImpl } from './smodel';
-import { SModelFactory } from "./smodel-factory";
+import { SModelFactory } from './smodel-factory';
 import { registerModelElement } from './smodel-utils';
-import { selectFeature, Selectable } from '../../features/select/model';
+import { selectFeature } from '../../features/select/model';
 import { boundsFeature } from '../../features/bounds/model';
-import defaultModule from "../di.config";
+import defaultModule from '../di.config';
 import { SModelElement } from 'sprotty-protocol';
 
 describe('model factory', () => {

--- a/packages/sprotty/src/features/bounds/abstract-layout.ts
+++ b/packages/sprotty/src/features/bounds/abstract-layout.ts
@@ -14,18 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
-import { SParentElementImpl, SModelElementImpl, SChildElementImpl } from "../../base/model/smodel";
-import { isLayoutContainer, isLayoutableChild, LayoutContainer, isBoundsAware } from "./model";
+import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
+import { SParentElementImpl, SModelElementImpl, SChildElementImpl } from '../../base/model/smodel';
+import { isLayoutContainer, isLayoutableChild, InternalLayoutContainer, isBoundsAware } from './model';
 import { ILayout, StatefulLayouter } from './layout';
 import { AbstractLayoutOptions, HAlignment, VAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
-import { injectable } from "inversify";
+import { injectable } from 'inversify';
 
 @injectable()
 export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements ILayout {
 
-    layout(container: SParentElementImpl & LayoutContainer,
+    layout(container: SParentElementImpl & InternalLayoutContainer,
            layouter: StatefulLayouter) {
         const boundsData = layouter.getBoundsData(container);
         const options = this.getLayoutOptions(container);
@@ -50,7 +50,7 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
                                 currentOffset: Point,
                                 maxWidth: number, maxHeight: number): Point;
 
-    protected getFinalContainerBounds(container: SParentElementImpl & LayoutContainer,
+    protected getFinalContainerBounds(container: SParentElementImpl & InternalLayoutContainer,
                                     lastOffset: Point,
                                     options: T,
                                     maxWidth: number,
@@ -85,11 +85,11 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
         }
     }
 
-    protected abstract getChildrenSize(container: SParentElementImpl & LayoutContainer,
+    protected abstract getChildrenSize(container: SParentElementImpl & InternalLayoutContainer,
                                containerOptions: T,
                                layouter: StatefulLayouter): Dimension;
 
-    protected layoutChildren(container: SParentElementImpl & LayoutContainer,
+    protected layoutChildren(container: SParentElementImpl & InternalLayoutContainer,
                             layouter: StatefulLayouter,
                             containerOptions: T,
                             maxWidth: number,

--- a/packages/sprotty/src/features/bounds/bounds-manipulation.ts
+++ b/packages/sprotty/src/features/bounds/bounds-manipulation.ts
@@ -16,11 +16,12 @@
 
 import { inject, injectable } from 'inversify';
 import { Action, ComputedBoundsAction, RequestBoundsAction, SetBoundsAction } from 'sprotty-protocol/lib/actions';
+import { Alignable } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { CommandExecutionContext, CommandResult, CommandReturn, HiddenCommand, SystemCommand } from '../../base/commands/command';
 import { SModelElementImpl } from '../../base/model/smodel';
 import { TYPES } from '../../base/types';
-import { Alignable, BoundsAware, isBoundsAware } from './model';
+import { BoundsAware, isBoundsAware } from './model';
 
 export interface ResolvedElementAndBounds {
     element: SModelElementImpl & BoundsAware

--- a/packages/sprotty/src/features/bounds/bounds-manipulation.ts
+++ b/packages/sprotty/src/features/bounds/bounds-manipulation.ts
@@ -21,10 +21,10 @@ import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { CommandExecutionContext, CommandResult, CommandReturn, HiddenCommand, SystemCommand } from '../../base/commands/command';
 import { SModelElementImpl } from '../../base/model/smodel';
 import { TYPES } from '../../base/types';
-import { BoundsAware, isBoundsAware } from './model';
+import { InternalBoundsAware, isBoundsAware } from './model';
 
 export interface ResolvedElementAndBounds {
-    element: SModelElementImpl & BoundsAware
+    element: SModelElementImpl & InternalBoundsAware
     oldBounds: Bounds
     newPosition?: Point
     newSize: Dimension

--- a/packages/sprotty/src/features/bounds/hbox-layout.ts
+++ b/packages/sprotty/src/features/bounds/hbox-layout.ts
@@ -20,7 +20,7 @@ import { SParentElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, VAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
-import { LayoutContainer, isLayoutableChild } from './model';
+import { InternalLayoutContainer, isLayoutableChild } from './model';
 import { StatefulLayouter } from './layout';
 
 export interface HBoxLayoutOptions extends AbstractLayoutOptions {
@@ -36,7 +36,7 @@ export class HBoxLayouter extends AbstractLayout<HBoxLayoutOptions> {
 
     static KIND = 'hbox';
 
-    protected getChildrenSize(container: SParentElementImpl & LayoutContainer,
+    protected getChildrenSize(container: SParentElementImpl & InternalLayoutContainer,
                                containerOptions: HBoxLayoutOptions,
                                layouter: StatefulLayouter) {
         let maxWidth = 0;

--- a/packages/sprotty/src/features/bounds/hidden-bounds-updater.ts
+++ b/packages/sprotty/src/features/bounds/hidden-bounds-updater.ts
@@ -25,7 +25,7 @@ import { SChildElementImpl, SModelElementImpl, SModelRootImpl } from '../../base
 import { TYPES } from '../../base/types';
 import { IVNodePostprocessor } from '../../base/views/vnode-postprocessor';
 import { Layouter } from './layout';
-import { BoundsAware, isAlignable, isLayoutContainer, isSizeable } from './model';
+import { InternalBoundsAware, isAlignable, isLayoutContainer, isSizeable } from './model';
 
 export class BoundsData {
     vnode?: VNode;
@@ -53,7 +53,7 @@ export class HiddenBoundsUpdater implements IVNodePostprocessor {
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(TYPES.Layouter) protected layouter: Layouter;
 
-    private readonly element2boundsData: Map<SModelElementImpl & BoundsAware, BoundsData> = new Map;
+    private readonly element2boundsData: Map<SModelElementImpl & InternalBoundsAware, BoundsData> = new Map;
 
     root: SModelRootImpl | undefined;
 
@@ -155,7 +155,7 @@ export class HiddenBoundsUpdater implements IVNodePostprocessor {
      * their parent, you can add the `ATTR_BBOX_ELEMENT` attribute to the SVG element
      * that shall be used to compute the bounding box.
      */
-    protected getBounds(elm: Node, element: SModelElementImpl & BoundsAware): Bounds {
+    protected getBounds(elm: Node, element: SModelElementImpl & InternalBoundsAware): Bounds {
         if (!isSVGGraphicsElement(elm)) {
             this.logger.error(this, 'Not an SVG element:', elm);
             return Bounds.EMPTY;

--- a/packages/sprotty/src/features/bounds/layout.ts
+++ b/packages/sprotty/src/features/bounds/layout.ts
@@ -20,7 +20,7 @@ import { TYPES } from "../../base/types";
 import { ILogger } from '../../utils/logging';
 import { InstanceRegistry } from "../../utils/registry";
 import { SParentElementImpl, SModelElementImpl } from "../../base/model/smodel";
-import { isLayoutContainer, LayoutContainer } from "./model";
+import { isLayoutContainer, InternalLayoutContainer } from "./model";
 import { BoundsData } from "./hidden-bounds-updater";
 import { isInjectable } from "../../utils/inversify";
 
@@ -59,7 +59,7 @@ export class Layouter {
 
 export class StatefulLayouter {
 
-    private toBeLayouted: (SParentElementImpl & LayoutContainer)[];
+    private toBeLayouted: (SParentElementImpl & InternalLayoutContainer)[];
 
     constructor(private readonly element2boundsData: Map<SModelElementImpl, BoundsData>,
                 private readonly layoutRegistry: LayoutRegistry,
@@ -96,7 +96,7 @@ export class StatefulLayouter {
         }
     }
 
-    protected doLayout(element: SParentElementImpl & LayoutContainer): Bounds {
+    protected doLayout(element: SParentElementImpl & InternalLayoutContainer): Bounds {
         const index = this.toBeLayouted.indexOf(element);
         if (index >= 0)
             this.toBeLayouted.splice(index, 1);
@@ -114,7 +114,7 @@ export class StatefulLayouter {
 }
 
 export interface ILayout {
-    layout(container: SParentElementImpl & LayoutContainer,
+    layout(container: SParentElementImpl & InternalLayoutContainer,
            layouter: StatefulLayouter): void
 }
 

--- a/packages/sprotty/src/features/bounds/model.ts
+++ b/packages/sprotty/src/features/bounds/model.ts
@@ -14,13 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Locateable } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, isBounds, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SChildElementImpl, SModelElementImpl, SModelRootImpl, SParentElementImpl } from '../../base/model/smodel';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { DOMHelper } from '../../base/views/dom-helper';
 import { ViewerOptions } from '../../base/views/viewer-options';
 import { getWindowScroll } from '../../utils/browser';
-import type { Locateable } from '../move/model';
 
 export const boundsFeature = Symbol('boundsFeature');
 export const layoutContainerFeature = Symbol('layoutContainerFeature');
@@ -34,25 +34,34 @@ export const alignFeature = Symbol('alignFeature');
  *
  * Feature extension interface for {@link boundsFeature}.
  */
-export interface BoundsAware {
+export interface InternalBoundsAware {
     bounds: Bounds
 }
+
+/** @deprecated Use `InternalBoundsAware` instead. */
+export type BoundsAware = InternalBoundsAware;
 
 /**
  * Used to identify model elements that specify a layout to apply to their children.
  */
-export interface LayoutContainer extends LayoutableChild {
+export interface InternalLayoutContainer extends InternalLayoutableChild {
     layout: string
 }
+
+/** @deprecated Use `InternalLayoutContainer` instead. */
+export type LayoutContainer = InternalLayoutContainer;
 
 export type ModelLayoutOptions = { [key: string]: string | number | boolean };
 
 /**
  * Feature extension interface for {@link layoutableChildFeature}.
  */
-export interface LayoutableChild extends BoundsAware {
+export interface InternalLayoutableChild extends InternalBoundsAware {
     layoutOptions?: ModelLayoutOptions
 }
+
+/** @deprecated Use `InternalLayoutableChild` instead. */
+export type LayoutableChild = InternalLayoutableChild;
 
 /**
  * Feature extension interface for {@link alignFeature}.
@@ -64,22 +73,22 @@ export interface Alignable {
     alignment: Point
 }
 
-export function isBoundsAware(element: SModelElementImpl): element is SModelElementImpl & BoundsAware {
+export function isBoundsAware(element: SModelElementImpl): element is SModelElementImpl & InternalBoundsAware {
     return 'bounds' in element;
 }
 
-export function isLayoutContainer(element: SModelElementImpl): element is SParentElementImpl & LayoutContainer {
+export function isLayoutContainer(element: SModelElementImpl): element is SParentElementImpl & InternalLayoutContainer {
     return isBoundsAware(element)
         && element.hasFeature(layoutContainerFeature)
         && 'layout' in element;
 }
 
-export function isLayoutableChild(element: SModelElementImpl): element is SChildElementImpl & LayoutableChild {
+export function isLayoutableChild(element: SModelElementImpl): element is SChildElementImpl & InternalLayoutableChild {
     return isBoundsAware(element)
         && element.hasFeature(layoutableChildFeature);
 }
 
-export function isSizeable(element: SModelElementImpl): element is SModelElementImpl & BoundsAware {
+export function isSizeable(element: SModelElementImpl): element is SModelElementImpl & InternalBoundsAware {
     return element.hasFeature(boundsFeature) && isBoundsAware(element);
 }
 
@@ -165,7 +174,7 @@ function doFindChildrenAtPosition(parent: SParentElementImpl, point: Point, matc
 /**
  * Abstract class for elements with a position and a size.
  */
-export abstract class SShapeElementImpl extends SChildElementImpl implements BoundsAware, Locateable, LayoutableChild {
+export abstract class SShapeElementImpl extends SChildElementImpl implements InternalBoundsAware, Locateable, InternalLayoutableChild {
 
     position: Point = Point.ORIGIN;
     size: Dimension = Dimension.EMPTY;

--- a/packages/sprotty/src/features/bounds/model.ts
+++ b/packages/sprotty/src/features/bounds/model.ts
@@ -55,10 +55,10 @@ export interface LayoutableChild extends BoundsAware {
 }
 
 /**
+ * Feature extension interface for {@link alignFeature}.
  * Used to adjust elements whose bounding box is not at the origin, e.g.
  * labels, or pre-rendered SVG figures.
- *
- * Feature extension interface for {@link alignFeature}.
+ * @deprecated use the definition from `sprotty-protocol` instead.
  */
 export interface Alignable {
     alignment: Point

--- a/packages/sprotty/src/features/bounds/resize.ts
+++ b/packages/sprotty/src/features/bounds/resize.ts
@@ -18,10 +18,10 @@ import { Dimension } from "sprotty-protocol/lib/utils/geometry";
 import { Animation } from "../../base/animations/animation";
 import { SModelRootImpl, SModelElementImpl } from "../../base/model/smodel";
 import { CommandExecutionContext } from "../../base/commands/command";
-import { BoundsAware } from './model';
+import { InternalBoundsAware } from './model';
 
 export interface ResolvedElementResize {
-    element: SModelElementImpl & BoundsAware
+    element: SModelElementImpl & InternalBoundsAware
     fromDimension: Dimension
     toDimension: Dimension
 }

--- a/packages/sprotty/src/features/bounds/stack-layout.ts
+++ b/packages/sprotty/src/features/bounds/stack-layout.ts
@@ -20,7 +20,7 @@ import { SParentElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, HAlignment, VAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
-import { LayoutContainer, isLayoutableChild } from './model';
+import { InternalLayoutContainer, isLayoutableChild } from './model';
 import { StatefulLayouter } from './layout';
 
 export interface StackLayoutOptions extends AbstractLayoutOptions {
@@ -34,7 +34,7 @@ export class StackLayouter extends AbstractLayout<StackLayoutOptions> {
 
     static KIND = 'stack';
 
-    protected getChildrenSize(container: SParentElementImpl & LayoutContainer,
+    protected getChildrenSize(container: SParentElementImpl & InternalLayoutContainer,
                             options: StackLayoutOptions,
                             layouter: StatefulLayouter) {
         let maxWidth = -1;

--- a/packages/sprotty/src/features/bounds/vbox-layout.ts
+++ b/packages/sprotty/src/features/bounds/vbox-layout.ts
@@ -20,7 +20,7 @@ import { SParentElementImpl, SChildElementImpl } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, HAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
-import { LayoutContainer, isLayoutableChild } from './model';
+import { InternalLayoutContainer, isLayoutableChild } from './model';
 import { StatefulLayouter } from './layout';
 
 export interface VBoxLayoutOptions extends AbstractLayoutOptions {
@@ -36,7 +36,7 @@ export class VBoxLayouter extends AbstractLayout<VBoxLayoutOptions> {
 
     static KIND = 'vbox';
 
-    protected getChildrenSize(container: SParentElementImpl & LayoutContainer,
+    protected getChildrenSize(container: SParentElementImpl & InternalLayoutContainer,
                                containerOptions: VBoxLayoutOptions,
                                layouter: StatefulLayouter) {
         let maxWidth = -1;

--- a/packages/sprotty/src/features/bounds/views.ts
+++ b/packages/sprotty/src/features/bounds/views.ts
@@ -18,7 +18,7 @@ import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { Dimension } from 'sprotty-protocol/lib/utils/geometry';
 import { IViewArgs, IView, RenderingContext } from '../../base/views/view';
-import { getAbsoluteBounds, BoundsAware } from './model';
+import { getAbsoluteBounds, InternalBoundsAware } from './model';
 import { SChildElementImpl } from '../../base/model/smodel';
 
 @injectable()
@@ -29,7 +29,7 @@ export abstract class ShapeView implements IView {
      * in your `render` implementation to skip rendering in case the element is not visible.
      * This can greatly enhance performance for large models.
      */
-    isVisible(model: Readonly<SChildElementImpl & BoundsAware>, context: RenderingContext): boolean {
+    isVisible(model: Readonly<SChildElementImpl & InternalBoundsAware>, context: RenderingContext): boolean {
         if (context.targetKind === 'hidden') {
             // Don't hide any element for hidden rendering
             return true;

--- a/packages/sprotty/src/features/button/model.ts
+++ b/packages/sprotty/src/features/button/model.ts
@@ -18,6 +18,9 @@ import { SShapeElement } from 'sprotty-protocol';
 import { boundsFeature, layoutableChildFeature, SShapeElementImpl } from '../bounds/model';
 import { fadeFeature } from '../fade/model';
 
+/**
+ * @deprecated Use SButton from `sprotty-protocol` instead.
+ */
 export interface SButtonSchema extends SShapeElement {
     pressed: boolean
     enabled: boolean

--- a/packages/sprotty/src/features/decoration/di.config.ts
+++ b/packages/sprotty/src/features/decoration/di.config.ts
@@ -16,13 +16,13 @@
 
 import { configureModelElement } from "../../base/views/view";
 import { ContainerModule } from "inversify";
-import { SIssueMarker } from "./model";
+import { SIssueMarkerImpl } from "./model";
 import { IssueMarkerView } from "./views";
 import { TYPES } from "../../base/types";
 import { DecorationPlacer } from "./decoration-placer";
 
 const decorationModule = new ContainerModule((bind, _unbind, isBound)  => {
-    configureModelElement({ bind, isBound }, 'marker', SIssueMarker, IssueMarkerView);
+    configureModelElement({ bind, isBound }, 'marker', SIssueMarkerImpl, IssueMarkerView);
     bind(DecorationPlacer).toSelf().inSingletonScope();
     bind(TYPES.IVNodePostprocessor).toService(DecorationPlacer);
 });

--- a/packages/sprotty/src/features/decoration/model.ts
+++ b/packages/sprotty/src/features/decoration/model.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { SIssue as SIssueSchema } from 'sprotty-protocol/lib/model';
 import { SModelElementImpl } from '../../base/model/smodel';
 import { SShapeElementImpl, boundsFeature } from '../bounds/model';
 import { hoverFeedbackFeature, popupFeature } from '../hover/model';
@@ -34,12 +35,21 @@ export class SDecoration extends SShapeElementImpl implements Decoration {
     static readonly DEFAULT_FEATURES = [decorationFeature, boundsFeature, hoverFeedbackFeature, popupFeature];
 }
 
-export type SIssueSeverity = 'error' | 'warning' | 'info';
-
-export class SIssueMarker extends SDecoration {
-    issues: SIssue[];
+export class SIssueMarkerImpl extends SDecoration {
+    issues: SIssueSchema[];
 }
 
+/** @deprecated Use SIssueMarkerImpl instead. */
+export const SIssueMarker = SIssueMarkerImpl;
+
+/**
+ * @deprecated Use the definition from `sprotty-protocol` instead.
+ */
+export type SIssueSeverity = 'error' | 'warning' | 'info';
+
+/**
+ * @deprecated Use the definition from `sprotty-protocol` instead.
+ */
 export class SIssue {
     message: string;
     severity: SIssueSeverity;

--- a/packages/sprotty/src/features/decoration/views.tsx
+++ b/packages/sprotty/src/features/decoration/views.tsx
@@ -19,13 +19,13 @@ import { svg } from '../../lib/jsx';
 
 import { VNode } from 'snabbdom';
 import { IView, RenderingContext } from '../../base/views/view';
-import { SIssueMarker, SIssueSeverity } from './model';
+import { SIssueMarkerImpl, SIssueSeverity } from './model';
 import { setClass } from '../../base/views/vnode-utils';
 import { injectable } from 'inversify';
 
 @injectable()
 export class IssueMarkerView implements IView {
-    render(marker: SIssueMarker, context: RenderingContext): VNode {
+    render(marker: SIssueMarkerImpl, context: RenderingContext): VNode {
         const scale = 16 / 1792;
         const trafo = `scale(${scale}, ${scale})`;
         const maxSeverity = this.getMaxSeverity(marker);
@@ -38,7 +38,7 @@ export class IssueMarkerView implements IView {
         return group;
     }
 
-    protected getMaxSeverity(marker: SIssueMarker): SIssueSeverity {
+    protected getMaxSeverity(marker: SIssueMarkerImpl): SIssueSeverity {
         let currentSeverity: SIssueSeverity = 'info';
         for (const severity of marker.issues.map(s => s.severity)) {
             if (severity === 'error' || (severity === 'warning' && currentSeverity === 'info'))

--- a/packages/sprotty/src/features/edge-layout/edge-layout.ts
+++ b/packages/sprotty/src/features/edge-layout/edge-layout.ts
@@ -23,7 +23,7 @@ import { IVNodePostprocessor } from '../../base/views/vnode-postprocessor';
 import { setAttr } from '../../base/views/vnode-utils';
 import { SEdgeImpl } from '../../graph/sgraph';
 import { Orientation } from '../../utils/geometry';
-import { isAlignable, BoundsAware } from '../bounds/model';
+import { isAlignable, InternalBoundsAware } from '../bounds/model';
 import { DEFAULT_EDGE_PLACEMENT, isEdgeLayoutable, checkEdgePlacement } from './model';
 import { EdgeRouterRegistry } from '../routing/routing';
 import { TYPES } from '../../base/types';
@@ -110,7 +110,7 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
         return vnode;
     }
 
-    protected getRotatedAlignment(element: EdgeLayoutable & SModelElementImpl & BoundsAware, placement: EdgePlacement, flip: boolean) {
+    protected getRotatedAlignment(element: EdgeLayoutable & SModelElementImpl & InternalBoundsAware, placement: EdgePlacement, flip: boolean) {
         let x = isAlignable(element) ? element.alignment.x : 0;
         let y = isAlignable(element) ? element.alignment.y : 0;
         const bounds = element.bounds;
@@ -168,7 +168,7 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
             (a, b) => { return {...a, ...b}; }, DEFAULT_EDGE_PLACEMENT);
     }
 
-    protected getAlignment(label: EdgeLayoutable & SModelElementImpl & BoundsAware, placement: EdgePlacement, angle: number): Point {
+    protected getAlignment(label: EdgeLayoutable & SModelElementImpl & InternalBoundsAware, placement: EdgePlacement, angle: number): Point {
         const bounds = label.bounds;
         const x = isAlignable(label) ? label.alignment.x - bounds.width : 0;
         const y = isAlignable(label) ? label.alignment.y - bounds.height : 0;

--- a/packages/sprotty/src/features/edge-layout/edge-layout.ts
+++ b/packages/sprotty/src/features/edge-layout/edge-layout.ts
@@ -14,19 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from "inversify";
-import { VNode } from "snabbdom";
-import { Bounds, Point, toDegrees } from "sprotty-protocol/lib/utils/geometry";
-import { SModelElementImpl, SChildElementImpl } from "../../base/model/smodel";
-import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
-import { setAttr } from "../../base/views/vnode-utils";
-import { SEdgeImpl } from "../../graph/sgraph";
-import { Orientation } from "../../utils/geometry";
-import { isAlignable, BoundsAware } from "../bounds/model";
-import { DEFAULT_EDGE_PLACEMENT, isEdgeLayoutable, EdgeLayoutable, EdgePlacement, checkEdgePlacement } from "./model";
-import { EdgeRouterRegistry } from "../routing/routing";
-import { TYPES } from "../../base/types";
-import { ILogger } from "../../utils/logging";
+import { injectable, inject } from 'inversify';
+import { VNode } from 'snabbdom';
+import { Bounds, Point, toDegrees } from 'sprotty-protocol/lib/utils/geometry';
+import { EdgeLayoutable, EdgePlacement } from 'sprotty-protocol/lib/model';
+import { SModelElementImpl, SChildElementImpl } from '../../base/model/smodel';
+import { IVNodePostprocessor } from '../../base/views/vnode-postprocessor';
+import { setAttr } from '../../base/views/vnode-utils';
+import { SEdgeImpl } from '../../graph/sgraph';
+import { Orientation } from '../../utils/geometry';
+import { isAlignable, BoundsAware } from '../bounds/model';
+import { DEFAULT_EDGE_PLACEMENT, isEdgeLayoutable, checkEdgePlacement } from './model';
+import { EdgeRouterRegistry } from '../routing/routing';
+import { TYPES } from '../../base/types';
+import { ILogger } from '../../utils/logging';
 
 @injectable()
 export class EdgeLayoutPostprocessor implements IVNodePostprocessor {

--- a/packages/sprotty/src/features/edge-layout/model.ts
+++ b/packages/sprotty/src/features/edge-layout/model.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import type { EdgePlacement as EdgePlacementSchema } from 'sprotty-protocol/lib/model';
 import { SModelElementImpl, SChildElementImpl } from '../../base/model/smodel';
 import { BoundsAware, isBoundsAware } from '../bounds/model';
 import { SRoutableElementImpl } from '../routing/model';
@@ -25,7 +26,7 @@ export const edgeLayoutFeature = Symbol('edgeLayout');
  * Feature extension interface for {@link edgeLayoutFeature}.
  */
 export interface EdgeLayoutable {
-    edgePlacement: EdgePlacement
+    edgePlacement: EdgePlacementSchema
 }
 
 export function isEdgeLayoutable<T extends SModelElementImpl>(element: T): element is T & SChildElementImpl & BoundsAware & EdgeLayoutable {
@@ -77,7 +78,7 @@ export class EdgePlacement extends Object {
 
 }
 
-export const DEFAULT_EDGE_PLACEMENT: EdgePlacement = {
+export const DEFAULT_EDGE_PLACEMENT: EdgePlacementSchema = {
     rotate: true,
     side: 'top',
     position: 0.5,

--- a/packages/sprotty/src/features/edge-layout/model.ts
+++ b/packages/sprotty/src/features/edge-layout/model.ts
@@ -16,7 +16,7 @@
 
 import type { EdgePlacement as EdgePlacementSchema } from 'sprotty-protocol/lib/model';
 import { SModelElementImpl, SChildElementImpl } from '../../base/model/smodel';
-import { BoundsAware, isBoundsAware } from '../bounds/model';
+import { InternalBoundsAware, isBoundsAware } from '../bounds/model';
 import { SRoutableElementImpl } from '../routing/model';
 
 export const edgeLayoutFeature = Symbol('edgeLayout');
@@ -29,7 +29,7 @@ export interface EdgeLayoutable {
     edgePlacement: EdgePlacementSchema
 }
 
-export function isEdgeLayoutable<T extends SModelElementImpl>(element: T): element is T & SChildElementImpl & BoundsAware & EdgeLayoutable {
+export function isEdgeLayoutable<T extends SModelElementImpl>(element: T): element is T & SChildElementImpl & InternalBoundsAware & EdgeLayoutable {
     return element instanceof SChildElementImpl
         && element.parent instanceof SRoutableElementImpl
         && isBoundsAware(element)

--- a/packages/sprotty/src/features/expand/model.ts
+++ b/packages/sprotty/src/features/expand/model.ts
@@ -19,9 +19,9 @@ import { SModelElementImpl } from '../../base/model/smodel';
 export const expandFeature = Symbol('expandFeature');
 
 /**
- * Model elements that implement this interface can be expanded/collapsed
- *
  * Feature extension interface for {@link expandFeature}.
+ * Model elements that implement this interface can be expanded/collapsed
+ * @deprecated Use the definition from `sprotty-protocol` instead.
  */
 export interface Expandable {
     expanded: boolean

--- a/packages/sprotty/src/features/fade/fade.ts
+++ b/packages/sprotty/src/features/fade/fade.ts
@@ -14,14 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable } from "inversify";
-import { VNode } from "snabbdom";
-import { Animation } from "../../base/animations/animation";
-import { CommandExecutionContext } from "../../base/commands/command";
-import { SModelRootImpl, SModelElementImpl, SChildElementImpl } from "../../base/model/smodel";
-import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
-import { setAttr } from "../../base/views/vnode-utils";
-import { Fadeable, isFadeable } from "./model";
+import { injectable } from 'inversify';
+import { VNode } from 'snabbdom';
+import { Fadeable } from 'sprotty-protocol/lib/model';
+import { Animation } from '../../base/animations/animation';
+import { CommandExecutionContext } from '../../base/commands/command';
+import { SModelRootImpl, SModelElementImpl, SChildElementImpl } from '../../base/model/smodel';
+import { IVNodePostprocessor } from '../../base/views/vnode-postprocessor';
+import { setAttr } from '../../base/views/vnode-utils';
+import { isFadeable } from './model';
 
 export interface ResolvedElementFade {
     element: SModelElementImpl & Fadeable

--- a/packages/sprotty/src/features/fade/model.ts
+++ b/packages/sprotty/src/features/fade/model.ts
@@ -19,7 +19,8 @@ import { SModelElementImpl } from '../../base/model/smodel';
 export const fadeFeature = Symbol('fadeFeature');
 
 /**
-* Feature extension interface for {@link fadeFeature}.
+ * Feature extension interface for {@link fadeFeature}.
+ * @deprecated Use the definition from `sprotty-protocol` instead.
  */
 export interface Fadeable {
     opacity: number

--- a/packages/sprotty/src/features/hover/hover.spec.ts
+++ b/packages/sprotty/src/features/hover/hover.spec.ts
@@ -14,16 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import "reflect-metadata";
+import 'reflect-metadata';
 import { expect, describe, it } from 'vitest';
-import { Container } from "inversify";
+import { Container } from 'inversify';
 import { Action, HoverFeedbackAction } from 'sprotty-protocol/lib/actions';
-import { TYPES } from "../../base/types";
-import { SChildElementImpl, SModelElementImpl, SModelRootImpl } from "../../base/model/smodel";
-import { HoverMouseListener } from "./hover";
-import { Hoverable, hoverFeedbackFeature, popupFeature } from "./model";
-import defaultModule from "../../base/di.config";
-import hoverModule from "./di.config";
+import { Hoverable } from 'sprotty-protocol/lib/model';
+import { TYPES } from '../../base/types';
+import { SChildElementImpl, SModelElementImpl, SModelRootImpl } from '../../base/model/smodel';
+import { HoverMouseListener } from './hover';
+import { hoverFeedbackFeature, popupFeature } from './model';
+import defaultModule from '../../base/di.config';
+import hoverModule from './di.config';
 
 describe('hover', () => {
     class HoverListenerMock extends HoverMouseListener {
@@ -72,7 +73,7 @@ describe('hover', () => {
     class HoverableTarget extends SModelElementImpl implements Hoverable {
         hoverFeedback: boolean = false;
 
-        constructor(id: string = "1") {
+        constructor(id: string = '1') {
             super();
             this.id = id;
         }
@@ -103,8 +104,8 @@ describe('hover', () => {
             expect((mouseOverResult[0] as Action).kind).to.equal(HoverFeedbackAction.KIND);
         });
         it('resets the hover feedback on hovering over another element', () => {
-            const target = new HoverableTarget("1");
-            const anotherTarget = new HoverableTarget("2");
+            const target = new HoverableTarget('1');
+            const anotherTarget = new HoverableTarget('2');
             hoverListener.mouseOver(target, event);
             const mouseOverResult: (Action | Promise<Action>)[] = hoverListener.mouseOver(anotherTarget, event);
 
@@ -132,8 +133,8 @@ describe('hover', () => {
         });
         it('resets the hover feedback when moving out of another element', () => {
             hoverListener.resetLastHoverFeedbackElement();
-            const target = new HoverableTarget("1");
-            const anotherTarget = new HoverableTarget("2");
+            const target = new HoverableTarget('1');
+            const anotherTarget = new HoverableTarget('2');
             hoverListener.mouseOver(target, event);
             const mouseOutResult: (Action | Promise<Action>)[] = hoverListener.mouseOut(anotherTarget, event);
 

--- a/packages/sprotty/src/features/hover/model.ts
+++ b/packages/sprotty/src/features/hover/model.ts
@@ -20,6 +20,7 @@ export const hoverFeedbackFeature = Symbol('hoverFeedbackFeature');
 
 /**
  * Feature extension interface for {@link hoverFeedbackFeature}.
+ * @deprecated Use the definition from `sprotty-protocol` instead.
  */
 export interface Hoverable {
     hoverFeedback: boolean

--- a/packages/sprotty/src/features/move/model.ts
+++ b/packages/sprotty/src/features/move/model.ts
@@ -14,23 +14,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SModelElementImpl } from '../../base/model/smodel';
 
 export const moveFeature = Symbol('moveFeature');
 
 /**
- * An element that can be placed at a specific location using its position
- * property.
- *
+ * An element that can be placed at a specific location using its position property.
  * Feature extension interface for {@link moveFeature}.
+ * @deprecated Use the definition from `sprotty-protocol` instead.
  */
 export interface Locateable {
     position: Point
 }
 
 export function isLocateable(element: SModelElementImpl): element is SModelElementImpl & Locateable {
-    return (element as any)['position'] !== undefined;
+    return hasOwnProperty(element, 'position');
 }
 
 export function isMoveable(element: SModelElementImpl): element is SModelElementImpl & Locateable {

--- a/packages/sprotty/src/features/move/move.ts
+++ b/packages/sprotty/src/features/move/move.ts
@@ -16,6 +16,7 @@
 
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
+import { Locateable } from 'sprotty-protocol/lib/model';
 import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { Action, DeleteElementAction, ReconnectAction, SelectAction, SelectAllAction, MoveAction } from 'sprotty-protocol/lib/actions';
 import { Animation, CompoundAnimation } from '../../base/animations/animation';
@@ -37,7 +38,7 @@ import { EdgeMemento, EdgeRouterRegistry, EdgeSnapshot, RoutedPoint } from '../r
 import { isEdgeLayoutable } from '../edge-layout/model';
 import { isSelectable } from '../select/model';
 import { isViewport } from '../viewport/model';
-import { isLocateable, isMoveable, Locateable } from './model';
+import { isLocateable, isMoveable } from './model';
 import { ISnapper } from './snap';
 
 export interface ElementMove {

--- a/packages/sprotty/src/features/projection/model.ts
+++ b/packages/sprotty/src/features/projection/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Viewport } from 'sprotty-protocol/lib/model';
+import { Projectable as ProjectableSchema, Viewport } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension } from 'sprotty-protocol/lib/utils/geometry';
 import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
 import { SChildElementImpl, SModelRootImpl, SParentElementImpl } from '../../base/model/smodel';
@@ -25,13 +25,14 @@ import { isBoundsAware } from '../bounds/model';
  * Model elements implementing this interface can be displayed on a projection bar.
  * _Note:_ If set, the projectedBounds property will be prefered over the model element bounds.
  * Otherwise model elements also have to be `BoundsAware` so their projections can be shown.
+ * @deprecated Use the definition from `sprotty-protocol` instead.
  */
 export interface Projectable {
     projectionCssClasses: string[],
     projectedBounds?: Bounds,
 }
 
-export function isProjectable(arg: unknown): arg is Projectable {
+export function isProjectable(arg: unknown): arg is ProjectableSchema {
     return hasOwnProperty(arg, 'projectionCssClasses');
 }
 
@@ -82,7 +83,7 @@ export function getProjections(parent: Readonly<SParentElementImpl>): ViewProjec
 /**
  * Compute the projected bounds of the given model element, that is the absolute position in the diagram.
  */
-export function getProjectedBounds(model: Readonly<SChildElementImpl & Projectable>): Bounds | undefined {
+export function getProjectedBounds(model: Readonly<SChildElementImpl & ProjectableSchema>): Bounds | undefined {
     const parent = model.parent;
     if (model.projectedBounds) {
         let bounds = model.projectedBounds;

--- a/packages/sprotty/src/features/routing/model.ts
+++ b/packages/sprotty/src/features/routing/model.ts
@@ -14,13 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Hoverable, Selectable } from 'sprotty-protocol/lib/model';
 import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SChildElementImpl, SModelElementImpl } from '../../base/model/smodel';
 import { FluentIterable } from '../../utils/iterable';
 import { SShapeElementImpl } from '../bounds/model';
 import { deletableFeature } from '../edit/delete';
-import { Selectable, selectFeature } from '../select/model';
-import { Hoverable, hoverFeedbackFeature } from '../hover/model';
+import { selectFeature } from '../select/model';
+import { hoverFeedbackFeature } from '../hover/model';
 import { moveFeature } from '../move/model';
 
 export abstract class SRoutableElementImpl extends SChildElementImpl {

--- a/packages/sprotty/src/features/select/model.ts
+++ b/packages/sprotty/src/features/select/model.ts
@@ -20,6 +20,7 @@ export const selectFeature = Symbol('selectFeature');
 
 /**
  * Feature extension interface for {@link selectFeature}.
+ * @deprecated Use the definition from `sprotty-protocol` instead.
  */
 export interface Selectable {
     selected: boolean

--- a/packages/sprotty/src/features/select/select.ts
+++ b/packages/sprotty/src/features/select/select.ts
@@ -16,7 +16,10 @@
 
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
-import { Action, BringToFrontAction, GetSelectionAction, ResponseAction, SelectAction, SelectAllAction, SelectionResult } from 'sprotty-protocol/lib/actions';
+import {
+    Action, BringToFrontAction, GetSelectionAction, ResponseAction, SelectAction, SelectAllAction, SelectionResult
+} from 'sprotty-protocol/lib/actions';
+import { Selectable } from 'sprotty-protocol/lib/model';
 import { Command, CommandExecutionContext } from '../../base/commands/command';
 import { ModelRequestCommand } from '../../base/commands/request-command';
 import { SChildElementImpl, SModelElementImpl, SModelRootImpl, SParentElementImpl } from '../../base/model/smodel';
@@ -34,7 +37,7 @@ import { SwitchEditModeAction } from '../edit/edit-routing';
 import { SRoutingHandleImpl } from '../routing/model';
 import { SRoutableElementImpl } from '../routing/model';
 import { findViewportScrollbar } from '../viewport/scroll';
-import { isSelectable, Selectable } from './model';
+import { isSelectable } from './model';
 
 @injectable()
 export class SelectCommand extends Command {

--- a/packages/sprotty/src/features/update/update-model.ts
+++ b/packages/sprotty/src/features/update/update-model.ts
@@ -16,13 +16,14 @@
 
 import { injectable, inject, optional } from 'inversify';
 import { UpdateModelAction } from 'sprotty-protocol/lib/actions';
+import { Fadeable } from 'sprotty-protocol/lib/model';
 import { almostEquals, Dimension } from 'sprotty-protocol/lib/utils/geometry';
 import { Animation, CompoundAnimation } from '../../base/animations/animation';
 import { CommandExecutionContext, CommandReturn, Command } from '../../base/commands/command';
 import { FadeAnimation, ResolvedElementFade } from '../fade/fade';
 import { SModelRootImpl, SChildElementImpl, SModelElementImpl, SParentElementImpl } from '../../base/model/smodel';
 import { MoveAnimation, ResolvedElementMove, MorphEdgesAnimation } from '../move/move';
-import { Fadeable, isFadeable } from '../fade/model';
+import { isFadeable } from '../fade/model';
 import { isLocateable } from '../move/model';
 import { isSizeable } from '../bounds/model';
 import { ViewportRootElementImpl } from '../viewport/viewport-root';

--- a/packages/sprotty/src/features/viewport/viewport-root.ts
+++ b/packages/sprotty/src/features/viewport/viewport-root.ts
@@ -19,13 +19,13 @@ import { Bounds, Dimension, isBounds, Point } from 'sprotty-protocol/lib/utils/g
 import { SModelRootImpl, ModelIndexImpl } from '../../base/model/smodel';
 import { viewportFeature } from "./model";
 import { exportFeature } from "../export/model";
-import { BoundsAware } from "../bounds/model";
+import { InternalBoundsAware } from "../bounds/model";
 
 /**
  * Model root element that defines a viewport, so it transforms the coordinate system with
  * a `scroll` translation and a `zoom` scaling.
  */
-export class ViewportRootElementImpl extends SModelRootImpl implements Viewport, BoundsAware {
+export class ViewportRootElementImpl extends SModelRootImpl implements Viewport, InternalBoundsAware {
     static readonly DEFAULT_FEATURES = [viewportFeature, exportFeature];
 
     scroll: Point = { x: 0, y: 0 };

--- a/packages/sprotty/src/graph/sgraph.ts
+++ b/packages/sprotty/src/graph/sgraph.ts
@@ -15,19 +15,20 @@
  ********************************************************************************/
 
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
+import { Alignable, EdgePlacement, Fadeable, Hoverable, Selectable } from 'sprotty-protocol/lib/model';
 import { ModelIndexImpl, SChildElementImpl, SModelElementImpl } from '../base/model/smodel';
 import {
-    Alignable, alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
+    alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
     ModelLayoutOptions, SShapeElementImpl
 } from '../features/bounds/model';
-import { edgeLayoutFeature, EdgePlacement } from '../features/edge-layout/model';
+import { edgeLayoutFeature } from '../features/edge-layout/model';
 import { deletableFeature } from '../features/edit/delete';
 import { editFeature } from '../features/edit/model';
-import { Fadeable, fadeFeature } from '../features/fade/model';
-import { Hoverable, hoverFeedbackFeature, popupFeature } from '../features/hover/model';
+import { fadeFeature } from '../features/fade/model';
+import { hoverFeedbackFeature, popupFeature } from '../features/hover/model';
 import { moveFeature } from '../features/move/model';
 import { connectableFeature, SConnectableElementImpl, SRoutableElementImpl } from '../features/routing/model';
-import { Selectable, selectFeature } from '../features/select/model';
+import { selectFeature } from '../features/select/model';
 import { ViewportRootElementImpl } from '../features/viewport/viewport-root';
 import { FluentIterable, FluentIterableImpl } from '../utils/iterable';
 

--- a/packages/sprotty/src/graph/sgraph.ts
+++ b/packages/sprotty/src/graph/sgraph.ts
@@ -18,7 +18,7 @@ import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { Alignable, EdgePlacement, Fadeable, Hoverable, Selectable } from 'sprotty-protocol/lib/model';
 import { ModelIndexImpl, SChildElementImpl, SModelElementImpl } from '../base/model/smodel';
 import {
-    alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
+    alignFeature, InternalBoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
     ModelLayoutOptions, SShapeElementImpl
 } from '../features/bounds/model';
 import { edgeLayoutFeature } from '../features/edge-layout/model';
@@ -118,7 +118,7 @@ export class SPortImpl extends SConnectableElementImpl implements Selectable, Fa
  * each of which can be either a node or a port. The source and target elements are referenced via their
  * ids and can be resolved with the index stored in the root element.
  */
-export class SEdgeImpl extends SRoutableElementImpl implements Fadeable, Selectable, Hoverable, BoundsAware {
+export class SEdgeImpl extends SRoutableElementImpl implements Fadeable, Selectable, Hoverable, InternalBoundsAware {
     static readonly DEFAULT_FEATURES = [editFeature, deletableFeature, selectFeature, fadeFeature,
         hoverFeedbackFeature];
 

--- a/packages/sprotty/src/lib/model.ts
+++ b/packages/sprotty/src/lib/model.ts
@@ -14,11 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Alignable, Selectable, SModelElement, SModelRoot } from 'sprotty-protocol/lib/model';
+import { Alignable, Locateable, Selectable, SModelElement, SModelRoot } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SModelRootImpl, SChildElementImpl } from '../base/model/smodel';
-import { BoundsAware, boundsFeature, alignFeature, isBoundsAware } from '../features/bounds/model';
-import { Locateable, moveFeature } from '../features/move/model';
+import { InternalBoundsAware, boundsFeature, alignFeature, isBoundsAware } from '../features/bounds/model';
+import { moveFeature } from '../features/move/model';
 import { selectFeature } from '../features/select/model';
 import { SNodeImpl, SPortImpl } from '../graph/sgraph';
 import { RECTANGULAR_ANCHOR_KIND, DIAMOND_ANCHOR_KIND, ELLIPTIC_ANCHOR_KIND } from '../features/routing/anchor';
@@ -120,7 +120,7 @@ export interface ShapedPreRenderedElementSchema extends PreRenderedElementSchema
 /**
  * Same as PreRenderedElement, but with a position and a size.
  */
-export class ShapedPreRenderedElementImpl extends PreRenderedElementImpl implements BoundsAware, Locateable, Selectable, Alignable {
+export class ShapedPreRenderedElementImpl extends PreRenderedElementImpl implements InternalBoundsAware, Locateable, Selectable, Alignable {
     static readonly DEFAULT_FEATURES = [moveFeature, boundsFeature, selectFeature, alignFeature];
 
     position: Point = Point.ORIGIN;

--- a/packages/sprotty/src/lib/model.ts
+++ b/packages/sprotty/src/lib/model.ts
@@ -14,14 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
-import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
-import { SModelRootImpl, SChildElementImpl } from "../base/model/smodel";
-import { BoundsAware, boundsFeature, Alignable, alignFeature, isBoundsAware } from "../features/bounds/model";
-import { Locateable, moveFeature } from "../features/move/model";
-import { Selectable, selectFeature } from "../features/select/model";
+import { Alignable, Selectable, SModelElement, SModelRoot } from 'sprotty-protocol/lib/model';
+import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
+import { SModelRootImpl, SChildElementImpl } from '../base/model/smodel';
+import { BoundsAware, boundsFeature, alignFeature, isBoundsAware } from '../features/bounds/model';
+import { Locateable, moveFeature } from '../features/move/model';
+import { selectFeature } from '../features/select/model';
 import { SNodeImpl, SPortImpl } from '../graph/sgraph';
-import { RECTANGULAR_ANCHOR_KIND, DIAMOND_ANCHOR_KIND, ELLIPTIC_ANCHOR_KIND } from "../features/routing/anchor";
+import { RECTANGULAR_ANCHOR_KIND, DIAMOND_ANCHOR_KIND, ELLIPTIC_ANCHOR_KIND } from '../features/routing/anchor';
 
 /**
  * A node that is represented by a circle.
@@ -73,7 +73,7 @@ export class RectangularPort extends SPortImpl {
  *
  * @deprecated Use `HtmlRoot` from `sprotty-protocol` instead.
  */
-export interface HtmlRootSchema extends SModelRootSchema {
+export interface HtmlRootSchema extends SModelRoot {
     classes?: string[]
 }
 
@@ -92,7 +92,7 @@ export const HtmlRoot = HtmlRootImpl;
  *
  * @deprecated Use `PreRenderedElement` from `sprotty-protocol` instead.
  */
-export interface PreRenderedElementSchema extends SModelElementSchema {
+export interface PreRenderedElementSchema extends SModelElement {
     code: string
 }
 

--- a/packages/sprotty/src/lib/svg-views.tsx
+++ b/packages/sprotty/src/lib/svg-views.tsx
@@ -15,17 +15,16 @@
  ********************************************************************************/
 
 /** @jsx svg */
-import { svg } from './jsx';
+import { svg } from './jsx';
 
-import { VNode } from "snabbdom";
+import { VNode } from 'snabbdom';
+import { Hoverable, Selectable } from 'sprotty-protocol/lib/model';
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
-import { IView, IViewArgs, RenderingContext } from "../base/views/view";
-import { SNodeImpl, SPortImpl } from "../graph/sgraph";
-import { ViewportRootElementImpl } from "../features/viewport/viewport-root";
+import { IView, IViewArgs, RenderingContext } from '../base/views/view';
+import { SNodeImpl, SPortImpl } from '../graph/sgraph';
+import { ViewportRootElementImpl } from '../features/viewport/viewport-root';
 import { SShapeElementImpl } from '../features/bounds/model';
 import { ShapeView } from '../features/bounds/views';
-import { Hoverable } from '../features/hover/model';
-import { Selectable } from '../features/select/model';
 import { Diamond } from '../utils/geometry';
 import { SModelElementImpl } from '../base/model/smodel';
 import { injectable } from 'inversify';


### PR DESCRIPTION
I moved most of the feature interfaces to the `sprotty-protocol` package so we can use them there. The old definitions are deprecated and can be removed in v2.0.0.