### PR TITLE
Make command executions (e.g. animations) stoppable

### DIFF
--- a/examples/circlegraph/src/standalone.ts
+++ b/examples/circlegraph/src/standalone.ts
@@ -77,11 +77,15 @@ export default async function runCircleGraph() {
         graph.children.push(...newElements);
     }
 
+    let viewport = initialViewport;
+    window.addEventListener('resize', async () => {
+        viewport = await modelSource.getViewport();
+    });
+
     // Run
     modelSource.setModel(graph);
 
     async function createNode(point?: Point) {
-        const viewport = await modelSource.getViewport();
         const newElements = addNode(getVisibleBounds(viewport));
         if (point) {
             const adjust = (offset: number) => {
@@ -103,7 +107,6 @@ export default async function runCircleGraph() {
     });
 
     document.getElementById('scrambleAll')!.addEventListener('click', async () => {
-        const viewport = await modelSource.getViewport();
         const bounds = getVisibleBounds(viewport);
         const nodeMoves: ElementMove[] = [];
         graph.children.forEach(shape => {
@@ -117,13 +120,12 @@ export default async function runCircleGraph() {
                 });
             }
         });
-        dispatcher.dispatch(MoveAction.create(nodeMoves, { animate: true }));
+        dispatcher.dispatch(MoveAction.create(nodeMoves, { animate: true, stoppable: true }));
         focusGraph();
     });
 
     document.getElementById('scrambleSelection')!.addEventListener('click', async () => {
         const selection = await modelSource.getSelection();
-        const viewport = await modelSource.getViewport();
         const bounds = getVisibleBounds(viewport);
         const nodeMoves: ElementMove[] = [];
         selection.forEach(shape => {
@@ -137,7 +139,7 @@ export default async function runCircleGraph() {
                 });
             }
         });
-        dispatcher.dispatch(MoveAction.create(nodeMoves, { animate: true }));
+        dispatcher.dispatch(MoveAction.create(nodeMoves, { animate: true, stoppable: true }));
         focusGraph();
     });
 

--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -676,16 +676,18 @@ export interface MoveAction extends Action {
     moves: ElementMove[]
     animate: boolean
     finished: boolean
+    stoppable: boolean
 }
 export namespace MoveAction {
     export const KIND = 'move';
 
-    export function create(moves: ElementMove[], options: { animate?: boolean, finished?: boolean } = {}): MoveAction {
+    export function create(moves: ElementMove[], options: { animate?: boolean, finished?: boolean, stoppable?: boolean } = {}): MoveAction {
         return {
             kind: KIND,
             moves,
             animate: options.animate ?? true,
-            finished: options.finished ?? false
+            finished: options.finished ?? false,
+            stoppable: options.stoppable ?? false
         };
     }
 }

--- a/packages/sprotty/src/base/commands/command.ts
+++ b/packages/sprotty/src/base/commands/command.ts
@@ -53,6 +53,17 @@ export interface ICommand {
 }
 
 /**
+ * A stoppable commands execution (e.g. one that starts an animation) can be interrupted.
+ */
+export interface IStoppableCommand extends ICommand {
+    stopExecution(): void
+}
+
+export function isStoppableCommand(command: any): command is IStoppableCommand {
+    return command && 'stopExecution' in command && typeof command.stopExecution === 'function';
+}
+
+/**
  * Commands return the changed model or a Promise for it. Promises
  * serve animating commands to render some intermediate states before
  * finishing. The CommandStack is in charge of chaining these promises,

--- a/packages/sprotty/src/features/move/move.ts
+++ b/packages/sprotty/src/features/move/move.ts
@@ -19,7 +19,7 @@ import { VNode } from 'snabbdom';
 import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { Action, DeleteElementAction, ReconnectAction, SelectAction, SelectAllAction, MoveAction } from 'sprotty-protocol/lib/actions';
 import { Animation, CompoundAnimation } from '../../base/animations/animation';
-import { CommandExecutionContext, ICommand, MergeableCommand, CommandReturn } from '../../base/commands/command';
+import { CommandExecutionContext, ICommand, MergeableCommand, CommandReturn, IStoppableCommand } from '../../base/commands/command';
 import { SChildElementImpl, SModelElementImpl, SModelRootImpl } from '../../base/model/smodel';
 import { findParentByFeature, translatePoint } from '../../base/model/smodel-utils';
 import { TYPES } from '../../base/types';
@@ -60,16 +60,25 @@ export interface ResolvedHandleMove {
 }
 
 @injectable()
-export class MoveCommand extends MergeableCommand {
+export class MoveCommand extends MergeableCommand implements IStoppableCommand {
     static readonly KIND = MoveAction.KIND;
 
     @inject(EdgeRouterRegistry) @optional() edgeRouterRegistry?: EdgeRouterRegistry;
 
     protected resolvedMoves: Map<string, ResolvedElementMove> = new Map;
     protected edgeMementi: EdgeMemento[] = [];
+    protected animation: Animation | undefined;
 
     constructor(@inject(TYPES.Action) protected readonly action: MoveAction) {
         super();
+    }
+
+    // stop the execution of the CompoundAnimation started below
+    stopExecution(): void {
+        if (this.animation) {
+            this.animation.stop();
+            this.animation = undefined;
+        }
     }
 
     execute(context: CommandExecutionContext): CommandReturn {
@@ -113,10 +122,10 @@ export class MoveCommand extends MergeableCommand {
         this.doMove(edge2handleMoves, attachedEdgeShifts);
         if (this.action.animate) {
             this.undoMove();
-            return new CompoundAnimation(context.root, context, [
+            return (this.animation = new CompoundAnimation(context.root, context, [
                 new MoveAnimation(context.root, this.resolvedMoves, context, false),
                 new MorphEdgesAnimation(context.root, this.edgeMementi, context, false)
-            ]).start();
+            ])).start();
         }
         return context.root;
     }


### PR DESCRIPTION
Commands that implement the new introduced IStoppableCommand do stop the last/current execution immediately to start another one of the same kind.

Solves https://github.com/eclipse-sprotty/sprotty/issues/1

It is nicely testable by raising the [duration time](https://github.com/jbicker/sprotty/blob/7d028502092be1533e60410cf824d83da8bcd4c7/packages/sprotty/src/base/di.config.ts#L86) of the CommandStackOptions and trigger the scrambling in the circle example multiple times.