### PR TITLE
Allow override of model element registration in DI

### DIFF
--- a/packages/sprotty/src/base/model/smodel-factory.ts
+++ b/packages/sprotty/src/base/model/smodel-factory.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2024 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -34,13 +34,25 @@ export class SModelRegistry extends FactoryRegistry<SModelElementImpl, void> {
                 defaultFeatures = [];
             if (defaultFeatures) {
                 const featureSet = createFeatureSet(defaultFeatures, registration.features);
-                this.register(registration.type, () => {
-                    const element = new registration.constr();
-                    element.features = featureSet;
-                    return element;
-                });
+                if (registration.isOverride) {
+                    this.override(registration.type, () => {
+                        const element = new registration.constr();
+                        element.features = featureSet;
+                        return element;
+                    });
+                } else {
+                    this.register(registration.type, () => {
+                        const element = new registration.constr();
+                        element.features = featureSet;
+                        return element;
+                    });
+                }
             } else {
-                this.register(registration.type, () => new registration.constr());
+                if (registration.isOverride) {
+                    this.override(registration.type, () => new registration.constr());
+                } else {
+                    this.register(registration.type, () => new registration.constr());
+                }
             }
         });
     }
@@ -177,6 +189,7 @@ export interface SModelElementRegistration {
     type: string
     constr: SModelElementConstructor
     features?: CustomFeatures
+    isOverride?: boolean
 }
 
 export interface SModelElementConstructor {

--- a/packages/sprotty/src/base/model/smodel-utils.ts
+++ b/packages/sprotty/src/base/model/smodel-utils.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2024 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,9 +24,9 @@ import { SModelElementRegistration, CustomFeatures } from "./smodel-factory";
  * Register a model element constructor for an element type.
  */
 export function registerModelElement(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
-        type: string, constr: new () => SModelElementImpl, features?: CustomFeatures): void {
+        type: string, constr: new () => SModelElementImpl, features?: CustomFeatures, isOverride?: boolean): void {
     context.bind<SModelElementRegistration>(TYPES.SModelElementRegistration).toConstantValue({
-        type, constr, features
+        type, constr, features, isOverride
     });
 }
 

--- a/packages/sprotty/src/utils/registry.ts
+++ b/packages/sprotty/src/utils/registry.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2024 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -60,7 +60,16 @@ export class FactoryRegistry<T, U> {
             throw new Error('Key is undefined');
         }
         if (this.hasKey(key)) {
-            throw new Error('Key is already registered: ' + key);
+            throw new Error(`Key is already registered: ${key}. Use \`overrideModelElement\` instead.`);
+        }
+        this.elements.set(key, factory);
+    }
+
+    override(key: string, factory: (u: U) => T) {
+        if (key === undefined) {
+            throw new Error('Key is undefined');
+        } else if (!this.hasKey(key)) {
+            throw new Error(`Key is not registered: ${key}. Use \`configureModelElement\` instead.`);
         }
         this.elements.set(key, factory);
     }
@@ -99,7 +108,16 @@ export class InstanceRegistry<T> {
             throw new Error('Key is undefined');
         }
         if (this.hasKey(key)) {
-            throw new Error('Key is already registered: ' + key);
+            throw new Error(`Key is already registered: ${key}. Use \`overrideModelElement\` instead.`);
+        }
+        this.elements.set(key, instance);
+    }
+
+    override(key: string, instance: T) {
+        if (key === undefined) {
+            throw new Error('Key is undefined');
+        } else if (!this.hasKey(key)) {
+            throw new Error(`Key is not registered: ${key}. Use \`configureModelElement\` instead.`);
         }
         this.elements.set(key, instance);
     }


### PR DESCRIPTION
Allow the element registration from the dependency injection to be overridden by another `ContainerModule`. This comes in handy when working with exported containers from the `sprotty-library` or when sharing  a `ContainerModule` when only a subset of model elements need a new registration.

This introduces a new helper function `overrideModelElement` to be used instead of `configureModelElement` in the `ContainerModule`

Example:
```
const moduleA = new ContainerModule((bind, unbind, isBound, rebind) => {
...
configureModelElement(context, 'myElementType', MyElementImplA, MyElementViewA);
}

const moduleB = new ContainerModule((bind, unbind, isBound, rebind) => {
...
overrideModelElement(context, 'myElementType', MyElementImplB, MyElementViewB);
}

const container = new Container();
loadDefaultModules(container);
container.load(moduleA);
container.load(moduleB);
```
In this scenario, `myElementType` elements will first be linked to `MyElementImplA` and `MyElementViewA` before being linked to `MyElementImplB` and `MyElementViewB`. 

If the order of the functions `container.load(...)` are reversed, so is the link between the element type and its implementation/view.

Error handling:
By design, we can only override an element that has already been configured.
* Trying to use `configureModelElement` on an element type that is already registered will throw an error
* Trying to use `overrideModelElement` on an element type that is not already registered will throw an error
