### PR TITLE
Do not set bend points on elk edge when transforming from Sprotty edge

### DIFF
--- a/packages/sprotty-elk/src/elk-layout.ts
+++ b/packages/sprotty-elk/src/elk-layout.ts
@@ -312,6 +312,10 @@ export class ElkLayoutEngine implements IModelLayoutEngine {
                 points.push(elkEdge.targetPoint);
             }
         }
+        // if x or y of first and last point are equal then use only them and leave the middle points
+        if (points.length > 1 && (points[0].x === points[points.length - 1].x || points[0].y === points[points.length - 1].y)) {
+            points.splice(1, points.length - 2);
+        }
         sedge.routingPoints = points;
 
         if (elkEdge.labels) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-sprotty/sprotty/issues/427

The bend points are now completely neglected in the edge transformation from SEdge to an ElkExtendedEdge. So elk sets completely new bend points.

Feels a bit like a naive fix but it works at least for the random graph example. I hope it does not break something else.