### PR TITLE
Corrected help link in examples

### DIFF
--- a/examples/circlegraph/circlegraph.html
+++ b/examples/circlegraph/circlegraph.html
@@ -21,7 +21,7 @@
                 </p>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div draggable="true" style="height: 70px; width: 70px;" ondragstart="dragstart(event)">

--- a/examples/classdiagram/class-diagram.html
+++ b/examples/classdiagram/class-diagram.html
@@ -32,7 +32,7 @@
                 <h1>Sprotty Class Diagram Example</h1>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div class="row">

--- a/examples/flowchart/flowchart.html
+++ b/examples/flowchart/flowchart.html
@@ -32,7 +32,7 @@
                 <h1>Sprotty Flowchart Example</h1>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div class="row">

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,7 +12,7 @@
         <div class="col-md-12">
             <h1>Sprotty Examples</h1>
             <a href="https://sprotty.org/">Sprotty</a> is a web-based diagramming framework.
-            For information how to use these examples see the <a href="https://sprotty.org/docs/user_interaction/">documentation</a>.
+            For information how to use these examples see the <a href="https://sprotty.org/docs/user-interaction/">documentation</a>.
 
             <h3>Without Server</h3>
             The following examples run completely in the browser and do not require any additional component.

--- a/examples/jsxample/jsxample.html
+++ b/examples/jsxample/jsxample.html
@@ -32,7 +32,7 @@
                 <h1>Sprotty JSXample</h1>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div class="row">

--- a/examples/multicore/multicore.html
+++ b/examples/multicore/multicore.html
@@ -16,7 +16,7 @@
                 <h1>Sprotty Multicore Example</h1>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div class="row" id="sprotty-app" data-app="multicore">

--- a/examples/random-graph-distributed/random-graph.html
+++ b/examples/random-graph-distributed/random-graph.html
@@ -16,7 +16,7 @@
                 <h1>Sprotty Random Graph Example</h1>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div class="row">

--- a/examples/random-graph/random-graph.html
+++ b/examples/random-graph/random-graph.html
@@ -25,7 +25,7 @@
                 </p>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div class="row">

--- a/examples/svg/svg-prerendered.html
+++ b/examples/svg/svg-prerendered.html
@@ -16,7 +16,7 @@
                 <h1>Sprotty Prerendered SVG / HTML Example</h1>
             </div>
             <div class="help col-md-2">
-                <a href="https://sprotty.org/docs/user_interaction/">Help</a>
+                <a href="https://sprotty.org/docs/user-interaction/">Help</a>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
After one of last changes of docs we forgot to correct the links to the interaction help page. This is corrected now.