### PR TITLE
Fix edge label placement

### DIFF
--- a/packages/sprotty/src/features/edge-layout/model.ts
+++ b/packages/sprotty/src/features/edge-layout/model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2024 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -82,6 +82,5 @@ export const DEFAULT_EDGE_PLACEMENT: EdgePlacementSchema = {
     rotate: true,
     side: 'top',
     position: 0.5,
-    offset: 7,
-    moveMode: 'edge'
+    offset: 7
 };


### PR DESCRIPTION
There was a bug where edge labels that do not contain an `edgePlacement` property would be positioned incorrectly