### PR TITLE
Adjust binding for `CommandActionHandlerInitializer`

### DIFF
--- a/packages/sprotty/src/base/di.config.ts
+++ b/packages/sprotty/src/base/di.config.ts
@@ -71,7 +71,8 @@ const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(TYPES.IDiagramLocker).to(DefaultDiagramLocker).inSingletonScope();
 
     // Action handler
-    bind(TYPES.IActionHandlerInitializer).to(CommandActionHandlerInitializer);
+    bind(CommandActionHandlerInitializer).toSelf().inSingletonScope();
+    bind(TYPES.IActionHandlerInitializer).toService(CommandActionHandlerInitializer);
 
     // Command Stack ---------------------------------------------
     bind(TYPES.ICommandStack).to(CommandStack).inSingletonScope();


### PR DESCRIPTION
Make is easier to customize/rebind the
`CommmandActionHandlerInitializer` by binding to itself before binding it as IActionHandlerInitializer.

(All other multiinjected keys already follow this pattern. See https://github.com/eclipse-sprotty/sprotty/issues/239)