### PR TITLE
Update inversify

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@vscode/codicons": "^0.0.33",
     "express": "^4.18.2",
-    "inversify": "~6.0.2",
+    "inversify": "^6.1.3",
     "reflect-metadata": "~0.1.14",
     "sprotty": "^1.3.0",
     "sprotty-elk": "^1.3.0",

--- a/packages/generator-sprotty/sprotty-local-template/package.json
+++ b/packages/generator-sprotty/sprotty-local-template/package.json
@@ -2,7 +2,7 @@
     "name": "<%= project-name %>",
     "description": "Please enter a brief description here",
     "dependencies": {
-      "inversify": "~6.0.2",
+      "inversify": "^6.1.3",
       "reflect-metadata": "^0.1.13",
       "sprotty": "^1.0.0"
     },

--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -25,7 +25,7 @@
     "sprotty-protocol": "^1.3.0"
   },
   "optionalDependencies": {
-    "inversify": "~6.0.2"
+    "inversify": "^6.1.3"
   },
   "volta": {
     "node": "18.19.0",

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "autocompleter": "^9.1.2",
     "file-saver": "^2.0.5",
-    "inversify": "~6.0.2",
+    "inversify": "^6.1.3",
     "snabbdom": "~3.5.1",
     "sprotty-protocol": "^1.3.0",
     "tinyqueue": "^2.0.3"

--- a/packages/sprotty/src/utils/inversify.ts
+++ b/packages/sprotty/src/utils/inversify.ts
@@ -13,7 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import {interfaces} from "inversify";
 
-export function isInjectable(constr: new (...args: unknown[]) => unknown): boolean {
+export function isInjectable(constr: interfaces.Newable<unknown>| Function ): boolean {
     return Reflect.getMetadata('inversify:paramtypes', constr) !== undefined;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,24 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@inversifyjs/common@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/common/-/common-1.4.0.tgz#4df42e8cb012a1630ebf2f3c65bb76ac5b0f3e4c"
+  integrity sha512-qfRJ/3iOlCL/VfJq8+4o5X4oA14cZSBbpAmHsYj8EsIit1xDndoOl0xKOyglKtQD4u4gdNVxMHx4RWARk/I4QA==
+
+"@inversifyjs/core@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/core/-/core-1.3.5.tgz#c02ee3ed036aae40189302794f16a9f4e0ed4557"
+  integrity sha512-B4MFXabhNTAmrfgB+yeD6wd/GIvmvWC6IQ8Rh/j2C3Ix69kmqwz9pr8Jt3E+Nho9aEHOQCZaGmrALgtqRd+oEQ==
+  dependencies:
+    "@inversifyjs/common" "1.4.0"
+    "@inversifyjs/reflect-metadata-utils" "0.2.4"
+
+"@inversifyjs/reflect-metadata-utils@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.4.tgz#c65172283db9516c4a27e8d673ca7a31a07d528b"
+  integrity sha512-u95rV3lKfG+NT2Uy/5vNzoDujos8vN8O18SSA5UyhxsGYd4GLQn/eUsGXfOsfa7m34eKrDelTKRUX1m/BcNX5w==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -3663,10 +3681,13 @@ interpret@^3.1.1:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
   integrity sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==
 
-inversify@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.0.2.tgz#dc7fa0348213d789d35ffb719dea9685570989c7"
-  integrity sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==
+inversify@^6.1.3:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.2.0.tgz#3c1a81bcd5722975f001a8af162c48255858daaa"
+  integrity sha512-wpiGpyIphFthWf18CBASJ1gClYwnW0mKjcSHwOuF7ToF/TBoarYSItX492WTGyK0VdJN1afwBIfaEpvp8IetPA==
+  dependencies:
+    "@inversifyjs/common" "1.4.0"
+    "@inversifyjs/core" "1.3.5"
 
 ip@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
The inversify dependency in sprotty is locked to 6.0.x. This version is now pretty outdated and there have been a lot of improvements in inversify.js that we can not consume yet.
In addition, this hardlock might block downstream projects.
In GLSP for instance, we might integrate into other components that also use inversify.js (e.g. Theia). 
Unfortunately, dependency injection breaks if multiple different inversify.js versions are resolved so we have to align this.

This change updates to the latest inversify.js version (using 6.1.3 as minimum version same as in Theia)
