### PR TITLE
Update reflect-metadata version in generator-sprotty

### DIFF
--- a/packages/generator-sprotty/sprotty-local-template/package.json
+++ b/packages/generator-sprotty/sprotty-local-template/package.json
@@ -3,7 +3,7 @@
     "description": "Please enter a brief description here",
     "dependencies": {
       "inversify": "^6.1.3",
-      "reflect-metadata": "^0.1.13",
+      "reflect-metadata": "^0.2.2",
       "sprotty": "^1.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
There is a conflict in the version of the package `reflect-metadata` in the generated `package.json` and the one expected by `inversify@6.2.2`. This would cause `npm install` to fail.