### PR TITLE
Add publish workflow to prepare OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,13 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          yarn
-          yarn build
+          npm install
+          npm run build
 
       - name: Test
         if: success() || failure()
         shell: bash
-        run: yarn test
+        run: npm run test
 
       - name: Publish
         uses: TypeFox/gh-publish-npm@7183224bef010236e419a2367208633ff284337a # v0.5.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  push:
+    # Only trigger on changes to package.json files in the main and maintenance branches
+    branches:
+      - 'main'
+      - 'maintenance/**'
+    paths:
+      - '**/package.json'
+
+jobs:
+  publish:
+    name: Sprotty Publish
+    runs-on: ubuntu-latest
+    environment: publish
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.2
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24.19.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build
+        shell: bash
+        run: |
+          yarn
+          yarn build
+
+      - name: Test
+        if: success() || failure()
+        shell: bash
+        run: yarn test
+
+      - name: Publish
+        uses: TypeFox/gh-publish-npm@7183224bef010236e419a2367208633ff284337a # v0.5.0
+        with:
+          dry-run: ${{ github.event_name == 'pull_request' }}
+          npm-packages: |
+            packages/sprotty
+            packages/sprotty-elk
+            packages/sprotty-library
+            packages/sprotty-protocol
+            packages/generator-sprotty


### PR DESCRIPTION
We want to migrate from local publishing to OIDC trusted publishing. This PR prepares this step by adding a workflow that runs on every change to a package.json file, compares the versions with what's on the registry, and publishes the packages if they're not on the registry yet.